### PR TITLE
feat: exponential backoff for rpc calls

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
+tokio-retry = "0.3"
 url = { version = "2.2.2", features = ["serde"] }
 futures = "0.3.16"
 

--- a/workspaces/src/rpc/api.rs
+++ b/workspaces/src/rpc/api.rs
@@ -1,4 +1,4 @@
-use super::client::client;
+use super::client;
 use super::tool;
 use super::types::{AccountInfo, NearBalance};
 
@@ -16,9 +16,7 @@ use near_jsonrpc_primitives::types::query::{QueryResponseKind, RpcQueryRequest};
 use near_primitives::borsh::BorshSerialize;
 use near_primitives::state_record::StateRecord;
 use near_primitives::transaction::SignedTransaction;
-use near_primitives::types::{
-    AccountId, Balance, BlockReference, Finality, FunctionArgs, Gas, StoreKey,
-};
+use near_primitives::types::{AccountId, Balance, Finality, FunctionArgs, Gas, StoreKey};
 use near_primitives::views::{FinalExecutionOutcomeView, QueryRequest};
 
 pub(crate) const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
@@ -27,20 +25,19 @@ const ERR_INVALID_VARIANT: &str =
 const DEV_ACCOUNT_SEED: &str = "testificate";
 const DEFAULT_CALL_FN_GAS: Gas = 10000000000000;
 
-pub async fn display_account_info(account_id: AccountId) -> Result<AccountInfo, String> {
-    let query_resp = client()
+pub async fn display_account_info(account_id: AccountId) -> anyhow::Result<AccountInfo> {
+    let query_resp = client::new()
         .call(&RpcQueryRequest {
             block_reference: Finality::Final.into(),
             request: QueryRequest::ViewAccount {
                 account_id: account_id.clone(),
             },
         })
-        .await
-        .map_err(|err| err.to_string())?;
+        .await?;
 
     let account_view = match query_resp.kind {
         QueryResponseKind::ViewAccount(result) => result,
-        _ => return Err("Error call result".to_owned()),
+        _ => return Err(anyhow!("Error call result")),
     };
 
     Ok(AccountInfo {
@@ -58,21 +55,21 @@ pub async fn transfer_near(
     signer_id: AccountId,
     receiver_id: AccountId,
     amount_yocto: Balance,
-) -> Result<FinalExecutionOutcomeView, String> {
-    let (access_key, _, block_hash) =
-        tool::access_key(signer_id.clone(), signer.public_key()).await?;
+) -> anyhow::Result<FinalExecutionOutcomeView> {
+    client::send_tx_and_retry(|| async {
+        let (access_key, _, block_hash) =
+            tool::access_key(signer_id.clone(), signer.public_key()).await?;
 
-    let tx = SignedTransaction::send_money(
-        access_key.nonce + 1,
-        signer_id,
-        receiver_id,
-        signer,
-        amount_yocto,
-        block_hash,
-    );
-
-    let transaction_info = tool::send_tx(tx).await?;
-    Ok(transaction_info)
+        Ok(SignedTransaction::send_money(
+            access_key.nonce + 1,
+            signer_id.clone(),
+            receiver_id.clone(),
+            signer,
+            amount_yocto,
+            block_hash,
+        ))
+    })
+    .await
 }
 
 pub async fn call(
@@ -82,72 +79,72 @@ pub async fn call(
     method_name: String,
     args: Vec<u8>,
     deposit: Option<Balance>,
-) -> Result<FinalExecutionOutcomeView, String> {
-    let (access_key, _, block_hash) =
-        tool::access_key(signer_id.clone(), signer.public_key()).await?;
-    let tx = SignedTransaction::call(
-        access_key.nonce + 1,
-        signer_id,
-        contract_id,
-        signer,
-        deposit.unwrap_or(0),
-        method_name,
-        args,
-        DEFAULT_CALL_FN_GAS,
-        block_hash,
-    );
-    let transaction_info = tool::send_tx(tx).await?;
-    Ok(transaction_info)
+) -> anyhow::Result<FinalExecutionOutcomeView> {
+    client::send_tx_and_retry(|| async {
+        let (access_key, _, block_hash) =
+            tool::access_key(signer_id.clone(), signer.public_key()).await?;
+
+        Ok(SignedTransaction::call(
+            access_key.nonce + 1,
+            signer_id.clone(),
+            contract_id.clone(),
+            signer,
+            deposit.unwrap_or(0),
+            method_name.clone(),
+            args.clone(),
+            DEFAULT_CALL_FN_GAS,
+            block_hash,
+        ))
+    })
+    .await
 }
 
 pub async fn view(
     contract_id: AccountId,
     method_name: String,
     args: FunctionArgs,
-) -> Result<serde_json::Value, String> {
-    let query_resp = client()
+) -> anyhow::Result<serde_json::Value> {
+    let query_resp = client::new()
         .call(&RpcQueryRequest {
-            block_reference: Finality::Final.into(),
+            block_reference: Finality::None.into(),
             request: QueryRequest::CallFunction {
                 account_id: contract_id,
                 method_name,
                 args,
             },
         })
-        .await
-        .map_err(|err| format!("Failed to fetch query for view method: {:?}", err))?;
+        .await?;
 
     let call_result = match query_resp.kind {
         QueryResponseKind::CallResult(result) => result.result,
-        _ => return Err("Error call result".to_string()),
+        _ => return Err(anyhow!("Error call result")),
     };
 
-    let call_result_str = String::from_utf8(call_result).map_err(|e| e.to_string())?;
-    let serde_call_result: serde_json::Value = serde_json::from_str(&call_result_str)
-        .map_err(|err| format!("serde_json error: {:?}", err))?;
-
-    Ok(serde_call_result)
+    let result = std::str::from_utf8(&call_result)?;
+    Ok(serde_json::from_str(result)?)
 }
 
 pub async fn view_state(
     contract_id: AccountId,
     prefix: Option<StoreKey>,
 ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
-    let query_resp = client()
-        .call(&methods::query::RpcQueryRequest {
-            block_reference: BlockReference::Finality(Finality::Final),
-            request: QueryRequest::ViewState {
-                account_id: contract_id,
-                prefix: prefix.unwrap_or_else(|| vec![].into()),
-            },
-        })
-        .await
-        .map_err(|err| anyhow!("Failed to query state: {:?}", err))?;
+    client::retry(|| async {
+        let query_resp = client::new()
+            .call(&methods::query::RpcQueryRequest {
+                block_reference: Finality::None.into(),
+                request: QueryRequest::ViewState {
+                    account_id: contract_id.clone(),
+                    prefix: prefix.clone().unwrap_or_else(|| vec![].into()),
+                },
+            })
+            .await?;
 
-    match query_resp.kind {
-        QueryResponseKind::ViewState(state) => tool::into_state_map(&state.values),
-        _ => Err(anyhow!(ERR_INVALID_VARIANT)),
-    }
+        match query_resp.kind {
+            QueryResponseKind::ViewState(state) => tool::into_state_map(&state.values),
+            _ => Err(anyhow!(ERR_INVALID_VARIANT)),
+        }
+    })
+    .await
 }
 
 pub async fn patch_state<T>(
@@ -169,13 +166,10 @@ where
     };
     let records = vec![state];
 
-    let query_resp = client()
+    let query_resp = client::new()
         .call(&RpcSandboxPatchStateRequest { records })
         .await
         .map_err(|err| format!("Failed to patch state: {:?}", err));
-
-    // TODO: Similar to `tool::send_tx`. Exponential Backoff required, so have this wait for state to be patched.
-    // tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
     query_resp
 }
@@ -187,21 +181,21 @@ pub async fn create_account(
     new_account_pk: PublicKey,
     deposit: Option<Balance>,
 ) -> anyhow::Result<FinalExecutionOutcomeView> {
-    let (access_key, _, block_hash) = tool::access_key(signer_id.clone(), signer.public_key())
-        .await
-        .map_err(|e| anyhow!(e))?;
+    client::send_tx_and_retry(|| async {
+        let (access_key, _, block_hash) =
+            tool::access_key(signer_id.clone(), signer.public_key()).await?;
 
-    let signed_tx = SignedTransaction::create_account(
-        access_key.nonce + 1,
-        signer_id,
-        new_account_id,
-        deposit.unwrap_or(NEAR_BASE),
-        new_account_pk,
-        signer,
-        block_hash,
-    );
-    let transaction_info = tool::send_tx(signed_tx).await.map_err(|e| anyhow!(e))?;
-    Ok(transaction_info)
+        Ok(SignedTransaction::create_account(
+            access_key.nonce + 1,
+            signer_id.clone(),
+            new_account_id.clone(),
+            deposit.unwrap_or(NEAR_BASE),
+            new_account_pk.clone(),
+            signer,
+            block_hash,
+        ))
+    })
+    .await
 }
 
 /// Creates a top level account. While in sandbox, we can grab the `ExecutionOutcomeView`, but
@@ -220,20 +214,21 @@ pub async fn delete_account(
     account_id: AccountId,
     signer: &dyn Signer,
     beneficiary_id: AccountId,
-) -> Result<FinalExecutionOutcomeView, String> {
-    let (access_key, _, block_hash) =
-        tool::access_key(account_id.clone(), signer.public_key()).await?;
+) -> anyhow::Result<FinalExecutionOutcomeView> {
+    client::send_tx_and_retry(|| async {
+        let (access_key, _, block_hash) =
+            tool::access_key(account_id.clone(), signer.public_key()).await?;
 
-    let signed_tx = SignedTransaction::delete_account(
-        access_key.nonce + 1,
-        account_id.clone(),
-        account_id,
-        beneficiary_id,
-        signer,
-        block_hash,
-    );
-    let transaction_info = tool::send_tx(signed_tx).await?;
-    Ok(transaction_info)
+        Ok(SignedTransaction::delete_account(
+            access_key.nonce + 1,
+            account_id.clone(),
+            account_id.clone(),
+            beneficiary_id.clone(),
+            signer,
+            block_hash,
+        ))
+    })
+    .await
 }
 
 fn dev_generate() -> (AccountId, InMemorySigner) {

--- a/workspaces/src/rpc/api.rs
+++ b/workspaces/src/rpc/api.rs
@@ -1,3 +1,4 @@
+use super::client::client;
 use super::tool;
 use super::types::{AccountInfo, NearBalance};
 
@@ -27,7 +28,7 @@ const DEV_ACCOUNT_SEED: &str = "testificate";
 const DEFAULT_CALL_FN_GAS: Gas = 10000000000000;
 
 pub async fn display_account_info(account_id: AccountId) -> Result<AccountInfo, String> {
-    let query_resp = tool::json_client()
+    let query_resp = client()
         .call(&RpcQueryRequest {
             block_reference: Finality::Final.into(),
             request: QueryRequest::ViewAccount {
@@ -104,7 +105,7 @@ pub async fn view(
     method_name: String,
     args: FunctionArgs,
 ) -> Result<serde_json::Value, String> {
-    let query_resp = tool::json_client()
+    let query_resp = client()
         .call(&RpcQueryRequest {
             block_reference: Finality::Final.into(),
             request: QueryRequest::CallFunction {
@@ -132,7 +133,7 @@ pub async fn view_state(
     contract_id: AccountId,
     prefix: Option<StoreKey>,
 ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
-    let query_resp = tool::json_client()
+    let query_resp = client()
         .call(&methods::query::RpcQueryRequest {
             block_reference: BlockReference::Finality(Finality::Final),
             request: QueryRequest::ViewState {
@@ -168,13 +169,13 @@ where
     };
     let records = vec![state];
 
-    let query_resp = tool::json_client()
+    let query_resp = client()
         .call(&RpcSandboxPatchStateRequest { records })
         .await
         .map_err(|err| format!("Failed to patch state: {:?}", err));
 
     // TODO: Similar to `tool::send_tx`. Exponential Backoff required, so have this wait for state to be patched.
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    // tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
     query_resp
 }

--- a/workspaces/src/rpc/api.rs
+++ b/workspaces/src/rpc/api.rs
@@ -59,7 +59,7 @@ pub async fn display_account_info(account_id: AccountId) -> anyhow::Result<Accou
 
     let account_view = match query_resp.kind {
         QueryResponseKind::ViewAccount(result) => result,
-        _ => return Err(anyhow!("Error call result")),
+        _ => anyhow::bail!("Incorrect query resp: maybe bug in rpc code?"),
     };
 
     Ok(AccountInfo {

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -25,7 +25,7 @@ pub(crate) fn new() -> RetryClient {
     RetryClient::new()
 }
 
-pub struct RetryClient;
+pub(crate) struct RetryClient;
 
 impl RetryClient {
     fn new() -> Self {

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -1,15 +1,15 @@
+// TODO: Remove this when near-jsonrpc-client crate no longer defaults to deprecation for
+//       warnings about unstable API.
+#![allow(deprecated)]
+
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tokio_retry::Retry;
 
-use near_jsonrpc_client::{methods::RpcMethod, JsonRpcClient, JsonRpcMethodCallResult};
+use near_jsonrpc_client::{methods, JsonRpcClient, JsonRpcMethodCallResult};
+use near_primitives::transaction::SignedTransaction;
+use near_primitives::views::FinalExecutionOutcomeView;
 
 use crate::runtime::context::MISSING_RUNTIME_ERROR;
-
-// Default number of retries with different nonce before giving up on a transaction.
-const TX_NONCE_RETRY_NUMBER: usize = 12;
-// Default wait until next retry in millis.
-const TX_NONCE_RETRY_WAIT: u64 = 100;
-
 
 fn rt_current_addr() -> String {
     crate::runtime::context::current()
@@ -17,50 +17,53 @@ fn rt_current_addr() -> String {
         .rpc_addr()
 }
 
-pub(crate) fn json_client() -> JsonRpcClient {
+fn json_client() -> JsonRpcClient {
     JsonRpcClient::connect(&rt_current_addr())
 }
 
-pub(crate) fn client() -> RetryClient {
+pub(crate) fn new() -> RetryClient {
     RetryClient::new()
 }
 
-pub struct RetryClient {
-    json_client: JsonRpcClient,
-}
+pub struct RetryClient;
 
 impl RetryClient {
     fn new() -> Self {
-        Self {
-            json_client: json_client(),
-        }
+        Self {}
     }
 
-    pub(crate) async fn call<M: RpcMethod>(
+    pub(crate) async fn call<M: methods::RpcMethod>(
         &self,
         method: &M,
     ) -> JsonRpcMethodCallResult<M::Result, M::Error> {
-        let mut c = 0;
-        // Need this because of the FnMut trait requirement:
-        let task = || {
-            c += 1;
-            println!("trying {}", c);
-            self.json_client.clone().call(method)
-        };
-
-        retry(task).await
+        retry(|| async { json_client().call(method).await }).await
     }
 }
 
 pub(crate) async fn retry<R, E, T, F>(task: F) -> T::Output
-// anyhow::Result<T::Output>
 where
     F: FnMut() -> T,
     T: core::future::Future<Output = Result<R, E>>,
 {
-    let retry_strategy = ExponentialBackoff::from_millis(TX_NONCE_RETRY_WAIT)
-        .map(jitter) // add jitter to delays
-        .take(TX_NONCE_RETRY_NUMBER);
+    // Exponential backoff starting w/ 10ms for maximum retry of 5 times:
+    let retry_strategy = ExponentialBackoff::from_millis(10).map(jitter).take(5);
 
     Retry::spawn(retry_strategy, task).await
+}
+
+pub(crate) async fn send_tx(tx: SignedTransaction) -> anyhow::Result<FinalExecutionOutcomeView> {
+    self::new()
+        .call(&methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
+            signed_transaction: tx.clone(),
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!(e))
+}
+
+pub(crate) async fn send_tx_and_retry<T, F>(task: F) -> anyhow::Result<FinalExecutionOutcomeView>
+where
+    F: Fn() -> T,
+    T: core::future::Future<Output = anyhow::Result<SignedTransaction>>,
+{
+    retry(|| async { send_tx(task().await?).await }).await
 }

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -1,0 +1,66 @@
+use tokio_retry::strategy::{jitter, ExponentialBackoff};
+use tokio_retry::Retry;
+
+use near_jsonrpc_client::{methods::RpcMethod, JsonRpcClient, JsonRpcMethodCallResult};
+
+use crate::runtime::context::MISSING_RUNTIME_ERROR;
+
+// Default number of retries with different nonce before giving up on a transaction.
+const TX_NONCE_RETRY_NUMBER: usize = 12;
+// Default wait until next retry in millis.
+const TX_NONCE_RETRY_WAIT: u64 = 100;
+
+
+fn rt_current_addr() -> String {
+    crate::runtime::context::current()
+        .expect(MISSING_RUNTIME_ERROR)
+        .rpc_addr()
+}
+
+pub(crate) fn json_client() -> JsonRpcClient {
+    JsonRpcClient::connect(&rt_current_addr())
+}
+
+pub(crate) fn client() -> RetryClient {
+    RetryClient::new()
+}
+
+pub struct RetryClient {
+    json_client: JsonRpcClient,
+}
+
+impl RetryClient {
+    fn new() -> Self {
+        Self {
+            json_client: json_client(),
+        }
+    }
+
+    pub(crate) async fn call<M: RpcMethod>(
+        &self,
+        method: &M,
+    ) -> JsonRpcMethodCallResult<M::Result, M::Error> {
+        let mut c = 0;
+        // Need this because of the FnMut trait requirement:
+        let task = || {
+            c += 1;
+            println!("trying {}", c);
+            self.json_client.clone().call(method)
+        };
+
+        retry(task).await
+    }
+}
+
+pub(crate) async fn retry<R, E, T, F>(task: F) -> T::Output
+// anyhow::Result<T::Output>
+where
+    F: FnMut() -> T,
+    T: core::future::Future<Output = Result<R, E>>,
+{
+    let retry_strategy = ExponentialBackoff::from_millis(TX_NONCE_RETRY_WAIT)
+        .map(jitter) // add jitter to delays
+        .take(TX_NONCE_RETRY_NUMBER);
+
+    Retry::spawn(retry_strategy, task).await
+}

--- a/workspaces/src/rpc/mod.rs
+++ b/workspaces/src/rpc/mod.rs
@@ -1,4 +1,4 @@
 pub mod api;
-mod client;
+pub(crate) mod client;
 pub(crate) mod tool;
 mod types;

--- a/workspaces/src/rpc/mod.rs
+++ b/workspaces/src/rpc/mod.rs
@@ -1,3 +1,4 @@
 pub mod api;
+mod client;
 pub(crate) mod tool;
 mod types;

--- a/workspaces/src/rpc/tool.rs
+++ b/workspaces/src/rpc/tool.rs
@@ -1,7 +1,3 @@
-// TODO: Remove this when near-jsonrpc-client crate no longer defaults to deprecation for
-//       warnings about unstable API.
-#![allow(deprecated)]
-
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::path::PathBuf;
@@ -11,34 +7,20 @@ use rand::Rng;
 use url::Url;
 
 use near_crypto::PublicKey;
-use near_jsonrpc_client::{
-    errors::{JsonRpcError, JsonRpcServerError},
-    methods, JsonRpcClient,
-};
-use near_jsonrpc_primitives::types::{query::QueryResponseKind, transactions::RpcTransactionError};
+use near_jsonrpc_client::methods;
+use near_jsonrpc_primitives::types::query::QueryResponseKind;
 use near_primitives::hash::CryptoHash;
-use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{AccountId, BlockHeight, Finality};
-use near_primitives::views::{AccessKeyView, FinalExecutionOutcomeView, QueryRequest, StateItem};
+use near_primitives::views::{AccessKeyView, QueryRequest, StateItem};
 
-use crate::rpc::client::client;
+use crate::rpc::client;
 use crate::runtime::context::MISSING_RUNTIME_ERROR;
-
-fn rt_current_addr() -> String {
-    crate::runtime::context::current()
-        .expect(MISSING_RUNTIME_ERROR)
-        .rpc_addr()
-}
-
-pub(crate) fn json_client() -> JsonRpcClient {
-    JsonRpcClient::connect(&rt_current_addr())
-}
 
 pub(crate) async fn access_key(
     account_id: AccountId,
     pk: PublicKey,
-) -> Result<(AccessKeyView, BlockHeight, CryptoHash), String> {
-    let query_resp = client()
+) -> anyhow::Result<(AccessKeyView, BlockHeight, CryptoHash)> {
+    let query_resp = client::new()
         .call(&methods::query::RpcQueryRequest {
             block_reference: Finality::Final.into(),
             request: QueryRequest::ViewAccessKey {
@@ -46,45 +28,14 @@ pub(crate) async fn access_key(
                 public_key: pk,
             },
         })
-        .await
-        .map_err(|err| format!("Failed to fetch public key info: {:?}", err))?;
+        .await?;
 
     match query_resp.kind {
         QueryResponseKind::AccessKey(access_key) => {
             Ok((access_key, query_resp.block_height, query_resp.block_hash))
         }
-        _ => Err("Could not retrieve access key".to_owned()),
+        _ => Err(anyhow::anyhow!("Could not retrieve access key")),
     }
-}
-
-pub(crate) async fn send_tx(tx: SignedTransaction) -> Result<FinalExecutionOutcomeView, String> {
-    let client = client();
-    let transaction_info_result = loop {
-        let transaction_info_result = client
-            .call(&methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest {
-                signed_transaction: tx.clone(),
-            })
-            .await;
-
-        if let Err(ref err) = transaction_info_result {
-            if matches!(
-                err,
-                JsonRpcError::ServerError(JsonRpcServerError::HandlerError(
-                    RpcTransactionError::TimeoutError
-                ))
-            ) {
-                eprintln!("transaction timeout: {:?}", err);
-                continue;
-            }
-        }
-
-        break transaction_info_result;
-    };
-
-    // TODO: remove this after adding exponential backoff
-    // tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
-
-    transaction_info_result.map_err(|e| format!("Error transaction: {:?}", e))
 }
 
 pub(crate) fn credentials_filepath(account_id: AccountId) -> anyhow::Result<PathBuf> {

--- a/workspaces/src/runtime/local.rs
+++ b/workspaces/src/runtime/local.rs
@@ -111,7 +111,7 @@ impl SandboxServer {
         self.process = Some(child);
 
         // TODO: Get rid of this sleep, and ping sandbox is alive instead:
-        thread::sleep(Duration::from_secs(3));
+        // thread::sleep(Duration::from_secs(3));
         Ok(())
     }
 }

--- a/workspaces/src/runtime/online.rs
+++ b/workspaces/src/runtime/online.rs
@@ -54,7 +54,7 @@ pub(crate) async fn create_tla_and_deploy(
     create_top_level_account(new_account_id.clone(), new_account_pk.clone()).await?;
 
     // TODO: backoff-and-retry: two separate transactions, requires a sleep in between.
-    tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+    // tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
     let (access_key, _, block_hash) = tool::access_key(new_account_id.clone(), new_account_pk)
         .await


### PR DESCRIPTION
Thought this was best to add next since CI builds are non-deterministic with sleeps and would fail sometimes. So all internal sleeps between each `call`/`view` function call are gone now. Also, won't likely have this for a while until near-api-rs is a thing in the middle, so might as well add it now and move it later.

`client.rs` handles most of the retry logic and also houses the logic for sending transactions

Also after this PR, completely addresses https://github.com/near/workspaces-rs/issues/7 by exposing mostly `anyhow::Result` for error handling, with the exception of one function left to be added by the spooning PR.