### PR TITLE
Stop exposing `FinalExecutionOutcomeView` as the return type of many call-like functions

### DIFF
--- a/workspaces/src/runtime/local.rs
+++ b/workspaces/src/runtime/local.rs
@@ -15,7 +15,7 @@ use near_primitives::views::FinalExecutionOutcomeView;
 use super::context;
 use super::RuntimeFlavor;
 use crate::rpc::tool;
-use crate::NEAR_BASE;
+use crate::{CallExecutionResult, NEAR_BASE};
 
 fn home_dir(port: u16) -> PathBuf {
     let mut path = std::env::temp_dir();
@@ -39,7 +39,7 @@ fn root_account() -> InMemorySigner {
 pub(crate) async fn create_top_level_account(
     new_account_id: AccountId,
     new_account_pk: PublicKey,
-) -> anyhow::Result<FinalExecutionOutcomeView> {
+) -> anyhow::Result<CallExecutionResult> {
     let root_signer = root_account();
     crate::create_account(
         &root_signer,

--- a/workspaces/src/runtime/mod.rs
+++ b/workspaces/src/runtime/mod.rs
@@ -13,6 +13,8 @@ use near_crypto::{PublicKey, Signer};
 use near_primitives::types::AccountId;
 use near_primitives::views::FinalExecutionOutcomeView;
 
+use crate::CallExecutionResult;
+
 const SANDBOX_CREDENTIALS_DIR: &str = ".near-credentials/sandbox/";
 const TESTNET_CREDENTIALS_DIR: &str = ".near-credentials/testnet/";
 
@@ -66,7 +68,7 @@ impl RuntimeFlavor {
         &self,
         new_account_id: AccountId,
         new_account_pk: PublicKey,
-    ) -> anyhow::Result<Option<FinalExecutionOutcomeView>> {
+    ) -> anyhow::Result<Option<CallExecutionResult>> {
         match self {
             Self::Sandbox(_) => Ok(Some(
                 local::create_top_level_account(new_account_id, new_account_pk).await?,


### PR DESCRIPTION
Resolves https://github.com/near/workspaces-rs/issues/21

The idea is to hide all the verbose information provided by `FinalExceutionOutcomeView` and its constituents. For now we are only interested in the outcome of the call along with the total gas burnt by the execution.