### PR TITLE
bugfix: Fixup race condition when installing near-sandbox

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -32,6 +32,9 @@ near-jsonrpc-primitives = "0.5"
 near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
 near-sandbox-utils = "0.1"
 
+[build-dependencies]
+near-sandbox-utils = "0.1"
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    near_sandbox_utils::install().expect("Could not install sandbox");
+}


### PR DESCRIPTION
Move installing the near-sandbox binary into `build.rs` as to not contend with multiple tests trying to install it at once.

Fixes: https://github.com/near/workspaces-rs/issues/44