### PR TITLE
refactor!: don't require owned AccountId for RPC abstractions

### DIFF
--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -39,7 +39,7 @@ async fn main() -> anyhow::Result<()> {
     println!("nft_mint outcome: {:#?}", outcome);
 
     let result: serde_json::Value = worker
-        .view(contract.id().clone(), "nft_metadata", Vec::new())
+        .view(contract.id(), "nft_metadata", Vec::new())
         .await?
         .json()?;
 

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -31,7 +31,7 @@ async fn create_ref(
     // service to pull down (i.e. greater than 50mb).
 
     owner
-        .call(&worker, ref_finance.id().clone(), "new")
+        .call(&worker, ref_finance.id(), "new")
         .args_json(serde_json::json!({
             "owner_id": ref_finance.id().clone(),
             "exchange_fee": 4,
@@ -41,7 +41,7 @@ async fn create_ref(
         .await?;
 
     owner
-        .call(&worker, ref_finance.id().clone(), "storage_deposit")
+        .call(&worker, ref_finance.id(), "storage_deposit")
         .args_json(serde_json::json!({}).to_string().into_bytes())?
         .deposit(parse_near!("30 mN"))
         .transact()
@@ -63,7 +63,7 @@ async fn create_wnear(
         .await?;
 
     owner
-        .call(&worker, wnear.id().clone(), "new")
+        .call(&worker, wnear.id(), "new")
         .args_json(serde_json::json!({
             "owner_id": owner.id().clone(),
             "total_supply": parse_near!("1,000,000,000 N"),
@@ -72,14 +72,14 @@ async fn create_wnear(
         .await?;
 
     owner
-        .call(&worker, wnear.id().clone(), "storage_deposit")
+        .call(&worker, wnear.id(), "storage_deposit")
         .args_json(serde_json::json!({}).to_string().into_bytes())?
         .deposit(parse_near!("0.008 N"))
         .transact()
         .await?;
 
     owner
-        .call(&worker, wnear.id().clone(), "near_deposit")
+        .call(&worker, wnear.id(), "near_deposit")
         .args_json(serde_json::json!({}).to_string().into_bytes())?
         .deposit(parse_near!("200 N"))
         .transact()
@@ -120,7 +120,7 @@ async fn create_pool_with_liquidity(
         .json()?;
 
     owner
-        .call(&worker, ref_finance.id().clone(), "register_tokens")
+        .call(&worker, ref_finance.id(), "register_tokens")
         .args_json(serde_json::json!({
             "token_ids": token_ids,
         }))?
@@ -131,7 +131,7 @@ async fn create_pool_with_liquidity(
     deposit_tokens(worker, owner, &ref_finance, tokens).await?;
 
     owner
-        .call(&worker, ref_finance.id().clone(), "add_liquidity")
+        .call(&worker, ref_finance.id(), "add_liquidity")
         .args_json(serde_json::json!({
             "pool_id": pool_id,
             "amounts": token_amounts,
@@ -153,7 +153,7 @@ async fn deposit_tokens(
     for (contract_id, amount) in tokens {
         ref_finance
             .as_account()
-            .call(&worker, contract_id.clone(), "storage_deposit")
+            .call(&worker, contract_id, "storage_deposit")
             .args_json(serde_json::json!({
                 "registration_only": true,
             }))?
@@ -162,7 +162,7 @@ async fn deposit_tokens(
             .await?;
 
         owner
-            .call(&worker, contract_id.clone(), "ft_transfer_call")
+            .call(&worker, contract_id, "ft_transfer_call")
             .args_json(serde_json::json!({
                 "receiver_id": ref_finance.id().clone(),
                 "amount": amount.to_string(),
@@ -308,7 +308,7 @@ async fn main() -> anyhow::Result<()> {
     assert_eq!(expected_return, "1662497915624478906119726");
 
     let actual_out = owner
-        .call(&worker, ref_finance.id().clone(), "swap")
+        .call(&worker, ref_finance.id(), "swap")
         .args_json(serde_json::json!({
             "actions": vec![serde_json::json!({
                 "pool_id": pool_id,

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -21,7 +21,7 @@ async fn create_ref(
     // This will pull down the relevant ref-finance contract from mainnet. We're going
     // to be overriding the initial balance with 1000N instead of what's on mainnet.
     let ref_finance = worker
-        .import_contract(ref_finance_id.clone(), &mainnet)
+        .import_contract(&ref_finance_id, &mainnet)
         .with_initial_balance(parse_near!("1000 N"))
         .transact()
         .await?;
@@ -58,7 +58,7 @@ async fn create_wnear(
     let mainnet = workspaces::mainnet();
     let wnear_id: AccountId = "wrap.near".to_string().try_into()?;
     let wnear = worker
-        .import_contract(wnear_id.clone(), &mainnet)
+        .import_contract(&wnear_id, &mainnet)
         .transact()
         .await?;
 
@@ -250,7 +250,7 @@ async fn main() -> anyhow::Result<()> {
 
     let ft_deposit: String = worker
         .view(
-            ref_finance.id().clone(),
+            ref_finance.id(),
             "get_deposit",
             serde_json::json!({
                 "account_id": owner.id().clone(),
@@ -266,7 +266,7 @@ async fn main() -> anyhow::Result<()> {
 
     let wnear_deposit: String = worker
         .view(
-            ref_finance.id().clone(),
+            ref_finance.id(),
             "get_deposit",
             serde_json::json!({
                 "account_id": owner.id().clone(),
@@ -287,7 +287,7 @@ async fn main() -> anyhow::Result<()> {
 
     let expected_return: String = worker
         .view(
-            ref_finance.id().clone(),
+            ref_finance.id(),
             "get_return",
             serde_json::json!({
                 "pool_id": pool_id,
@@ -337,7 +337,7 @@ async fn main() -> anyhow::Result<()> {
 
     let ft_deposit: String = worker
         .view(
-            ref_finance.id().clone(),
+            ref_finance.id(),
             "get_deposit",
             serde_json::json!({
                 "account_id": owner.id().clone(),

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -69,7 +69,7 @@ async fn main() -> anyhow::Result<()> {
             .try_into()
             .unwrap();
 
-        let mut state_items = worker.view_state(contract_id.clone(), None).await.unwrap();
+        let mut state_items = worker.view_state(&contract_id, None).await.unwrap();
 
         let state = state_items.remove("STATE").unwrap();
         let status_msg: StatusMessage =
@@ -90,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
     // Patch our testnet STATE into our local sandbox:
     worker
         .patch_state(
-            sandbox_contract.id().clone(),
+            sandbox_contract.id(),
             "STATE".to_string(),
             status_msg.try_to_vec()?,
         )

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -157,7 +157,7 @@ impl Contract {
         function: &str,
         args: Vec<u8>,
     ) -> anyhow::Result<ViewResultDetails> {
-        worker.view(self.id().clone(), function, args).await
+        worker.view(self.id(), function, args).await
     }
 
     /// Deletes the current contract, and returns the execution details of this

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -42,7 +42,12 @@ impl Account {
         contract_id: &AccountId,
         function: &str,
     ) -> CallBuilder<'a, T> {
-        CallBuilder::new(worker, contract_id.to_owned(), self.signer.clone(), function.into())
+        CallBuilder::new(
+            worker,
+            contract_id.to_owned(),
+            self.signer.clone(),
+            function.into(),
+        )
     }
 
     /// Transfer NEAR to an account specified by `receiver_id` with the amount
@@ -297,12 +302,7 @@ where
         let outcome = self
             .worker
             .client()
-            .create_account(
-                &self.signer,
-                &id,
-                sk.public_key(),
-                self.initial_balance,
-            )
+            .create_account(&self.signer, &id, sk.public_key(), self.initial_balance)
             .await?;
 
         let signer = InMemorySigner::from_secret_key(id.clone(), sk);

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -39,10 +39,10 @@ impl Account {
     pub fn call<'a, T: Network>(
         &self,
         worker: &'a Worker<T>,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         function: &str,
     ) -> CallBuilder<'a, T> {
-        CallBuilder::new(worker, contract_id, self.signer.clone(), function.into())
+        CallBuilder::new(worker, contract_id.to_owned(), self.signer.clone(), function.into())
     }
 
     /// Transfer NEAR to an account specified by `receiver_id` with the amount
@@ -50,7 +50,7 @@ impl Account {
     pub async fn transfer_near<T: Network>(
         &self,
         worker: &Worker<T>,
-        receiver_id: AccountId,
+        receiver_id: &AccountId,
         amount: Balance,
     ) -> anyhow::Result<CallExecutionDetails> {
         worker
@@ -63,10 +63,10 @@ impl Account {
     pub async fn delete_account<T: Network>(
         self,
         worker: &Worker<T>,
-        beneficiary_id: AccountId,
+        beneficiary_id: &AccountId,
     ) -> anyhow::Result<CallExecutionDetails> {
         worker
-            .delete_account(self.id, &self.signer, beneficiary_id)
+            .delete_account(&self.id, &self.signer, beneficiary_id)
             .await
     }
 
@@ -95,7 +95,7 @@ impl Account {
     ) -> anyhow::Result<CallExecution<Contract>> {
         let outcome = worker
             .client()
-            .deploy(&self.signer, self.id().clone(), wasm.as_ref().into())
+            .deploy(&self.signer, self.id(), wasm.as_ref().into())
             .await?;
 
         Ok(CallExecution {
@@ -146,7 +146,7 @@ impl Contract {
         worker: &'a Worker<T>,
         function: &str,
     ) -> CallBuilder<'a, T> {
-        self.account.call(worker, self.id().clone(), function)
+        self.account.call(worker, self.id(), function)
     }
 
     /// Call a view function into the current contract. Returns a result that
@@ -165,7 +165,7 @@ impl Contract {
     pub async fn delete_contract<T: Network>(
         self,
         worker: &Worker<T>,
-        beneficiary_id: AccountId,
+        beneficiary_id: &AccountId,
     ) -> anyhow::Result<CallExecutionDetails> {
         self.account.delete_account(worker, beneficiary_id).await
     }
@@ -230,7 +230,7 @@ impl<'a, T: Network> CallBuilder<'a, T> {
             .client()
             .call(
                 &self.signer,
-                self.contract_id,
+                &self.contract_id,
                 self.function,
                 self.args,
                 self.gas,
@@ -299,7 +299,7 @@ where
             .client()
             .create_account(
                 &self.signer,
-                id.clone(),
+                &id,
                 sk.public_key(),
                 self.initial_balance,
             )

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -1,5 +1,4 @@
 use std::path::PathBuf;
-use std::str::FromStr;
 
 use async_trait::async_trait;
 
@@ -22,7 +21,7 @@ impl Mainnet {
             client: Client::new(RPC_URL.into()),
             info: Info {
                 name: "mainnet".into(),
-                root_id: AccountId::from_str("near").unwrap(),
+                root_id: "near".parse().unwrap(),
                 keystore_path: PathBuf::from(".near-credentials/mainnet/"),
                 rpc_url: RPC_URL.into(),
             },

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -100,14 +100,14 @@ pub trait AllowStatePatching {}
 pub trait StatePatcher {
     async fn patch_state(
         &self,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         key: String,
         value: Vec<u8>,
     ) -> anyhow::Result<()>;
 
     fn import_contract<'a, 'b>(
         &'b self,
-        id: AccountId,
+        id: &AccountId,
         worker: &'a Worker<impl Network>,
     ) -> ImportContractBuilder<'a, 'b>;
 }
@@ -119,12 +119,12 @@ where
 {
     async fn patch_state(
         &self,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         key: String,
         value: Vec<u8>,
     ) -> anyhow::Result<()> {
         let state = StateRecord::Data {
-            account_id: contract_id,
+            account_id: contract_id.to_owned(),
             data_key: key.into(),
             value,
         };
@@ -142,10 +142,10 @@ where
 
     fn import_contract<'a, 'b>(
         &'b self,
-        id: AccountId,
+        id: &AccountId,
         worker: &'a Worker<impl Network>,
     ) -> ImportContractBuilder<'a, 'b> {
-        ImportContractBuilder::new(id, worker.client(), self.client())
+        ImportContractBuilder::new(id.to_owned(), worker.client(), self.client())
     }
 }
 

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -91,13 +91,7 @@ impl TopLevelAccountCreator for Sandbox {
         let root_signer = self.root_signer();
         let outcome = self
             .client
-            .create_account_and_deploy(
-                &root_signer,
-                &id,
-                sk.public_key(),
-                DEFAULT_DEPOSIT,
-                wasm,
-            )
+            .create_account_and_deploy(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT, wasm)
             .await?;
 
         let signer = InMemorySigner::from_secret_key(id.clone(), sk);

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -72,7 +72,7 @@ impl TopLevelAccountCreator for Sandbox {
         let root_signer = self.root_signer();
         let outcome = self
             .client
-            .create_account(&root_signer, id.clone(), sk.public_key(), DEFAULT_DEPOSIT)
+            .create_account(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT)
             .await?;
 
         let signer = InMemorySigner::from_secret_key(id.clone(), sk);
@@ -93,7 +93,7 @@ impl TopLevelAccountCreator for Sandbox {
             .client
             .create_account_and_deploy(
                 &root_signer,
-                id.clone(),
+                &id,
                 sk.public_key(),
                 DEFAULT_DEPOSIT,
                 wasm,

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -70,7 +70,7 @@ impl TopLevelAccountCreator for Testnet {
         let signer = InMemorySigner::from_secret_key(id.clone(), sk.clone());
         let account = self.create_tla(id.clone(), sk).await?;
         let account = account.into_result()?;
-        let outcome = self.client.deploy(&signer, id, wasm).await?;
+        let outcome = self.client.deploy(&signer, &id, wasm).await?;
 
         Ok(CallExecution {
             result: Contract::account(account),

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -47,7 +47,7 @@ impl Client {
     async fn send_tx_and_retry(
         &self,
         signer: &InMemorySigner,
-        receiver_id: AccountId,
+        receiver_id: &AccountId,
         action: Action,
     ) -> anyhow::Result<FinalExecutionOutcomeView> {
         send_batch_tx_and_retry(self, signer, receiver_id, vec![action]).await
@@ -56,7 +56,7 @@ impl Client {
     pub(crate) async fn call(
         &self,
         signer: &InMemorySigner,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         method_name: String,
         args: Vec<u8>,
         gas: Gas,
@@ -184,7 +184,7 @@ impl Client {
     pub(crate) async fn deploy(
         &self,
         signer: &InMemorySigner,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         wasm: Vec<u8>,
     ) -> anyhow::Result<FinalExecutionOutcomeView> {
         self.send_tx_and_retry(
@@ -199,7 +199,7 @@ impl Client {
     pub(crate) async fn transfer_near(
         &self,
         signer: &InMemorySigner,
-        receiver_id: AccountId,
+        receiver_id: &AccountId,
         amount_yocto: Balance,
     ) -> anyhow::Result<FinalExecutionOutcomeView> {
         self.send_tx_and_retry(
@@ -216,7 +216,7 @@ impl Client {
     pub(crate) async fn create_account(
         &self,
         signer: &InMemorySigner,
-        new_account_id: AccountId,
+        new_account_id: &AccountId,
         new_account_pk: PublicKey,
         amount: Balance,
     ) -> anyhow::Result<FinalExecutionOutcomeView> {
@@ -243,7 +243,7 @@ impl Client {
     pub(crate) async fn create_account_and_deploy(
         &self,
         signer: &InMemorySigner,
-        new_account_id: AccountId,
+        new_account_id: &AccountId,
         new_account_pk: PublicKey,
         amount: Balance,
         code: Vec<u8>,
@@ -273,9 +273,10 @@ impl Client {
     pub(crate) async fn delete_account(
         &self,
         signer: &InMemorySigner,
-        account_id: AccountId,
-        beneficiary_id: AccountId,
+        account_id: &AccountId,
+        beneficiary_id: &AccountId,
     ) -> anyhow::Result<FinalExecutionOutcomeView> {
+        let beneficiary_id = beneficiary_id.to_owned();
         self.send_tx_and_retry(
             signer,
             account_id,
@@ -343,7 +344,7 @@ where
 async fn send_batch_tx_and_retry(
     client: &Client,
     signer: &InMemorySigner,
-    receiver_id: AccountId,
+    receiver_id: &AccountId,
     actions: Vec<Action>,
 ) -> anyhow::Result<FinalExecutionOutcomeView> {
     send_tx_and_retry(client, || async {

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -63,7 +63,7 @@ where
 {
     async fn patch_state(
         &self,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         key: String,
         value: Vec<u8>,
     ) -> anyhow::Result<()> {
@@ -72,7 +72,7 @@ where
 
     fn import_contract<'a, 'b>(
         &'b self,
-        id: AccountId,
+        id: &AccountId,
         worker: &'a Worker<impl Network>,
     ) -> ImportContractBuilder<'a, 'b> {
         self.workspace.import_contract(id, worker)
@@ -110,19 +110,21 @@ where
 
     pub async fn view(
         &self,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         function: &str,
         args: Vec<u8>,
     ) -> anyhow::Result<ViewResultDetails> {
-        self.client().view(contract_id, function.into(), args).await
+        self.client()
+            .view(contract_id.clone(), function.into(), args)
+            .await
     }
 
     pub async fn view_state(
         &self,
-        contract_id: AccountId,
+        contract_id: &AccountId,
         prefix: Option<StoreKey>,
     ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
-        self.client().view_state(contract_id, prefix).await
+        self.client().view_state(contract_id.clone(), prefix).await
     }
 
     pub async fn transfer_near(

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -98,7 +98,7 @@ where
         self.client()
             .call(
                 contract.signer(),
-                contract.id().clone(),
+                contract.id(),
                 function.into(),
                 args,
                 gas.unwrap_or(DEFAULT_CALL_FN_GAS),
@@ -130,7 +130,7 @@ where
     pub async fn transfer_near(
         &self,
         signer: &InMemorySigner,
-        receiver_id: AccountId,
+        receiver_id: &AccountId,
         amount_yocto: Balance,
     ) -> anyhow::Result<CallExecutionDetails> {
         self.client()
@@ -141,9 +141,9 @@ where
 
     pub async fn delete_account(
         &self,
-        account_id: AccountId,
+        account_id: &AccountId,
         signer: &InMemorySigner,
-        beneficiary_id: AccountId,
+        beneficiary_id: &AccountId,
     ) -> anyhow::Result<CallExecutionDetails> {
         self.client()
             .delete_account(signer, account_id, beneficiary_id)

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -31,7 +31,7 @@ async fn view_status_state(
         .transact()
         .await?;
 
-    let mut state_items = worker.view_state(contract.id().clone(), None).await?;
+    let mut state_items = worker.view_state(contract.id(), None).await?;
     let state = state_items
         .remove("STATE")
         .ok_or_else(|| anyhow::anyhow!("Could not retrieve STATE"))?;
@@ -69,7 +69,7 @@ async fn test_patch_state() -> anyhow::Result<()> {
 
     worker
         .patch_state(
-            contract_id.clone(),
+            &contract_id,
             "STATE".to_string(),
             status_msg.try_to_vec()?,
         )
@@ -77,7 +77,7 @@ async fn test_patch_state() -> anyhow::Result<()> {
 
     let status: String = worker
         .view(
-            contract_id.clone(),
+            &contract_id,
             "get_status",
             json!({
                 "account_id": "alice.near",

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -68,11 +68,7 @@ async fn test_patch_state() -> anyhow::Result<()> {
     });
 
     worker
-        .patch_state(
-            &contract_id,
-            "STATE".to_string(),
-            status_msg.try_to_vec()?,
-        )
+        .patch_state(&contract_id, "STATE".to_string(), status_msg.try_to_vec()?)
         .await?;
 
     let status: String = worker


### PR DESCRIPTION
There doesn't seem to me to be any requirement for these to be owned, given that they are just used to be serialized when sending a request. This is all very opinionated and I also have to think through the implications and future direction a lot more, but curious what you think @ChaoticTempest 

There were also some that could be changed with creating TLA (but this one seemed like owned might have a reason). Also, there are other parameters this could be done with, but trying to limit the scope.