### PR TITLE
feat: Switch prints to `tracing`

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,6 +12,8 @@ near-units = "0.1.0"
 # arbitrary_precision enabled for u128 types that workspaces requires for Balance types
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 tokio = { version = "1.10.0", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 workspaces = { path = "../workspaces" }
 
 [[example]]

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -23,6 +23,7 @@ serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
+tracing = "0.1.29"
 url = { version = "2.2.2", features = ["serde"] }
 
 near-account-id = "0.5"
@@ -40,3 +41,6 @@ libc = "0.2"
 
 [dev-dependencies]
 borsh = "0.9"
+env_logger = "0.9.0"
+test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
+tracing-subscriber = {version = "0.3.5", default-features = false, features = ["env-filter", "fmt"]}

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -23,7 +23,7 @@ serde = "1.0"
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
 tokio-retry = "0.3"
-tracing = "0.1.29"
+tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
 
 near-account-id = "0.5"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -41,6 +41,5 @@ libc = "0.2"
 
 [dev-dependencies]
 borsh = "0.9"
-env_logger = "0.9.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
-tracing-subscriber = {version = "0.3.5", default-features = false, features = ["env-filter", "fmt"]}
+tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -1,7 +1,6 @@
 use std::process::Child;
-
+use tracing::info;
 use portpicker::pick_unused_port;
-
 use crate::network::Sandbox;
 
 pub struct SandboxServer {
@@ -20,7 +19,7 @@ impl SandboxServer {
     }
 
     pub fn start(&mut self) -> anyhow::Result<()> {
-        println!("Starting up sandbox at localhost:{}", self.rpc_port);
+        info!(target: "workspaces", "Starting up sandbox at localhost:{}", self.rpc_port);
         let home_dir = Sandbox::home_dir(self.rpc_port);
 
         // Remove dir if it already exists:
@@ -28,7 +27,7 @@ impl SandboxServer {
         near_sandbox_utils::init(&home_dir)?.wait()?;
 
         let child = near_sandbox_utils::run(&home_dir, self.rpc_port, self.net_port)?;
-        println!("Started sandbox: pid={:?}", child.id());
+        info!(target: "workspaces", "Started sandbox: pid={:?}", child.id());
         self.process = Some(child);
 
         Ok(())
@@ -55,7 +54,8 @@ impl Drop for SandboxServer {
 
         let child = self.process.as_mut().unwrap();
 
-        eprintln!(
+        info!(
+            target: "workspaces",
             "Cleaning up sandbox: port={}, pid={}",
             self.rpc_port,
             child.id()

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -1,7 +1,7 @@
+use crate::network::Sandbox;
+use portpicker::pick_unused_port;
 use std::process::Child;
 use tracing::info;
-use portpicker::pick_unused_port;
-use crate::network::Sandbox;
 
 pub struct SandboxServer {
     pub(crate) rpc_port: u16,

--- a/workspaces/tests/create_account.rs
+++ b/workspaces/tests/create_account.rs
@@ -1,6 +1,7 @@
+use test_log::test;
 use workspaces::prelude::*;
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_subaccount_creation() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let account = worker.dev_create_account().await?;

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-
+use test_log::test;
 use workspaces::prelude::*;
 
 const NFT_WASM_FILEPATH: &str = "../examples/res/non_fungible_token.wasm";
@@ -28,7 +28,7 @@ fn expected() -> NftMetadata {
     serde_json::from_str(EXPECTED_NFT_METADATA).unwrap()
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_dev_deploy() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let wasm = std::fs::read(NFT_WASM_FILEPATH)?;

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -1,6 +1,6 @@
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use serde_json::json;
-
+use test_log::test;
 use workspaces::prelude::*;
 use workspaces::{AccountId, DevNetwork, Worker};
 
@@ -40,7 +40,7 @@ async fn view_status_state(
     Ok((contract.id().clone(), status_msg))
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_view_state() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let (contract_id, status_msg) = view_status_state(worker).await?;
@@ -58,7 +58,7 @@ async fn test_view_state() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
+#[test(tokio::test)]
 async fn test_patch_state() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let (contract_id, mut status_msg) = view_status_state(worker.clone()).await?;


### PR DESCRIPTION
Fixes #26 

I chose `tracing` since this is what `nearcore` is using and due to its extensive features such as layered spans and subscription mechanisms that can be useful for monitoring further down the line. As per conversation under the issue, it does not necessarily tie us to `tokio` ecosystem either.

Unfortunately, the sandbox logs are being produced by a dynamically downloaded binary file, so they do not respect the logging configuration (`RUST_LOG`, `RUST_LOG_STYLE` and others). See #53. This means that for now users will see logs being printed in an inconsistent manner like this:
```
2022-01-12T01:05:05.814561Z  INFO workspaces: Starting up sandbox at localhost:15562
2022-01-12T01:05:05.814601Z  INFO workspaces: Starting up sandbox at localhost:15965
Jan 12 12:05:05.817  INFO neard: Version: trunk, Build: 2c9375ee, Latest Protocol: 48
Jan 12 12:05:05.817  INFO neard: Version: trunk, Build: 2c9375ee, Latest Protocol: 48
Jan 12 12:05:05.817  INFO near: Generated node key, validator key, genesis file in /tmp/sandbox-15965
Jan 12 12:05:05.817  INFO near: Generated node key, validator key, genesis file in /tmp/sandbox-15562
2022-01-12T01:05:05.817696Z  INFO workspaces: Started sandbox: pid=12175
2022-01-12T01:05:05.817866Z  INFO workspaces: Started sandbox: pid=12176
```