### PR TITLE
refactor: (dev_)deploy is now consistent across the board

### DIFF
--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -8,7 +8,7 @@ const NFT_WASM_FILEPATH: &str = "./examples/res/non_fungible_token.wasm";
 async fn main() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let wasm = std::fs::read(NFT_WASM_FILEPATH)?;
-    let contract = worker.dev_deploy(wasm).await?;
+    let contract = worker.dev_deploy(&wasm).await?;
 
     let outcome = contract
         .call(&worker, "new_default_meta")

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -180,7 +180,7 @@ async fn create_custom_ft(
     worker: &Worker<impl DevNetwork>,
 ) -> anyhow::Result<Contract> {
     let ft: Contract = worker
-        .dev_deploy(std::fs::read(FT_CONTRACT_FILEPATH)?)
+        .dev_deploy(&std::fs::read(FT_CONTRACT_FILEPATH)?)
         .await?;
 
     // Initialize our FT contract with owner metadata and total supply available

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -43,7 +43,7 @@ async fn deploy_status_contract(
     msg: &str,
 ) -> anyhow::Result<Contract> {
     let wasm = std::fs::read(STATUS_MSG_WASM_FILEPATH)?;
-    let contract = worker.dev_deploy(wasm).await?;
+    let contract = worker.dev_deploy(&wasm).await?;
 
     // This will `call` into `set_status` with the message we want to set.
     contract

--- a/examples/src/status_message.rs
+++ b/examples/src/status_message.rs
@@ -7,7 +7,7 @@ const STATUS_MSG_WASM_FILEPATH: &str = "./examples/res/status_message.wasm";
 async fn main() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let wasm = std::fs::read(STATUS_MSG_WASM_FILEPATH)?;
-    let contract = worker.dev_deploy(wasm).await?;
+    let contract = worker.dev_deploy(&wasm).await?;
 
     let outcome = contract
         .call(&worker, "set_status")

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -31,7 +31,6 @@ near-primitives = "0.5"
 near-jsonrpc-primitives = "0.5"
 near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
 near-sandbox-utils = "0.1"
-# near-sandbox-utils = { path = "../../../sandbox/crate" }
 
 [build-dependencies]
 near-sandbox-utils = "0.1"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -31,6 +31,7 @@ near-primitives = "0.5"
 near-jsonrpc-primitives = "0.5"
 near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
 near-sandbox-utils = "0.1"
+# near-sandbox-utils = { path = "../../../sandbox/crate" }
 
 [build-dependencies]
 near-sandbox-utils = "0.1"

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -93,10 +93,10 @@ impl Account {
 
     /// Deploy contract code or WASM bytes to the account, and return us a new
     /// [`Contract`] object that we can use to interact with the contract.
-    pub async fn deploy<T: Network, U: AsRef<[u8]>>(
+    pub async fn deploy<T: Network>(
         &self,
         worker: &Worker<T>,
-        wasm: U,
+        wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>> {
         let outcome = worker
             .client()

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -43,7 +43,7 @@ impl TopLevelAccountCreator for Mainnet {
         &self,
         _id: AccountId,
         _sk: SecretKey,
-        _wasm: Vec<u8>,
+        _wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>> {
         panic!("Unsupported for now: https://github.com/near/workspaces-rs/issues/18");
     }

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -45,7 +45,7 @@ pub trait TopLevelAccountCreator {
         &self,
         id: AccountId,
         sk: SecretKey,
-        wasm: Vec<u8>,
+        wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>>;
 }
 
@@ -57,7 +57,7 @@ pub trait AllowDevAccountCreation {}
 pub trait DevAccountDeployer {
     async fn dev_generate(&self) -> (AccountId, SecretKey);
     async fn dev_create_account(&self) -> anyhow::Result<Account>;
-    async fn dev_deploy(&self, wasm: Vec<u8>) -> anyhow::Result<Contract>;
+    async fn dev_deploy(&self, wasm: &[u8]) -> anyhow::Result<Contract>;
 }
 
 #[async_trait]
@@ -87,7 +87,7 @@ where
         account.into()
     }
 
-    async fn dev_deploy(&self, wasm: Vec<u8>) -> anyhow::Result<Contract> {
+    async fn dev_deploy(&self, wasm: &[u8]) -> anyhow::Result<Contract> {
         let (id, sk) = self.dev_generate().await;
         let contract = self.create_tla_and_deploy(id.clone(), sk, wasm).await?;
         contract.into()

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -91,7 +91,13 @@ impl TopLevelAccountCreator for Sandbox {
         let root_signer = self.root_signer();
         let outcome = self
             .client
-            .create_account_and_deploy(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT, wasm.into())
+            .create_account_and_deploy(
+                &root_signer,
+                &id,
+                sk.public_key(),
+                DEFAULT_DEPOSIT,
+                wasm.into(),
+            )
             .await?;
 
         let signer = InMemorySigner::from_secret_key(id.clone(), sk);

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -86,12 +86,12 @@ impl TopLevelAccountCreator for Sandbox {
         &self,
         id: AccountId,
         sk: SecretKey,
-        wasm: Vec<u8>,
+        wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>> {
         let root_signer = self.root_signer();
         let outcome = self
             .client
-            .create_account_and_deploy(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT, wasm)
+            .create_account_and_deploy(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT, wasm.into())
             .await?;
 
         let signer = InMemorySigner::from_secret_key(id.clone(), sk);

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -65,12 +65,13 @@ impl TopLevelAccountCreator for Testnet {
         &self,
         id: AccountId,
         sk: SecretKey,
-        wasm: Vec<u8>,
+        wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>> {
         let signer = InMemorySigner::from_secret_key(id.clone(), sk.clone());
         let account = self.create_tla(id.clone(), sk).await?;
         let account = account.into_result()?;
-        let outcome = self.client.deploy(&signer, &id, wasm).await?;
+
+        let outcome = self.client.deploy(&signer, &id, wasm.into()).await?;
 
         Ok(CallExecution {
             result: Contract::account(account),

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -41,7 +41,7 @@ where
         &self,
         id: AccountId,
         sk: SecretKey,
-        wasm: Vec<u8>,
+        wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>> {
         self.workspace.create_tla_and_deploy(id, sk, wasm).await
     }

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -32,7 +32,7 @@ fn expected() -> NftMetadata {
 async fn test_dev_deploy() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
     let wasm = std::fs::read(NFT_WASM_FILEPATH)?;
-    let contract = worker.dev_deploy(wasm).await?;
+    let contract = worker.dev_deploy(&wasm).await?;
 
     let _result = contract
         .call(&worker, "new_default_meta")

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -21,7 +21,7 @@ async fn view_status_state(
     worker: Worker<impl DevNetwork>,
 ) -> anyhow::Result<(AccountId, StatusMessage)> {
     let wasm = std::fs::read(STATUS_MSG_WASM_FILEPATH)?;
-    let contract = worker.dev_deploy(wasm).await.unwrap();
+    let contract = worker.dev_deploy(&wasm).await.unwrap();
 
     contract
         .call(&worker, "set_status")


### PR DESCRIPTION
Refactored `account.deploy` and `worker.dev_deploy` to be consistent with each other