### PR TITLE
Adds mainnet archival rpc and fixes ref-finance example

### DIFF
--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -26,7 +26,7 @@ async fn create_ref(
     // to be overriding the initial balance with 1000N instead of what's on mainnet.
     let ref_finance = worker
         .import_contract(&ref_finance_id, &mainnet)
-        .with_initial_balance(parse_near!("1000 N"))
+        .initial_balance(parse_near!("1000 N"))
         .block_id(BLOCK_ID)
         .transact()
         .await?;

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, convert::TryInto};
 
 use near_units::{parse_gas, parse_near};
-use workspaces::{prelude::*, BlockId, DevNetwork};
+use workspaces::{prelude::*, BlockHeight, DevNetwork};
 use workspaces::{Account, AccountId, Contract, Network, Worker};
 
 const FT_CONTRACT_FILEPATH: &str = "./examples/res/fungible_token.wasm";
@@ -11,7 +11,7 @@ const REF_FINANCE_ACCOUNT_ID: &str = "v2.ref-finance.near";
 
 /// BlockId referencing back to a specific time just in case the contract has
 /// changed or has been updated at a later time.
-const BLOCK_ID: BlockId = BlockId::Height(50_000_000);
+const BLOCK_HEIGHT: BlockHeight = 50_000_000;
 
 /// Pull down the ref-finance contract and deploy it to the sandbox network,
 /// initializing it with all data required to run the tests.
@@ -27,7 +27,7 @@ async fn create_ref(
     let ref_finance = worker
         .import_contract(&ref_finance_id, &mainnet)
         .initial_balance(parse_near!("1000 N"))
-        .block_id(BLOCK_ID)
+        .block_height(BLOCK_HEIGHT)
         .transact()
         .await?;
 
@@ -63,7 +63,7 @@ async fn create_wnear(
     let wnear_id: AccountId = "wrap.near".to_string().try_into()?;
     let wnear = worker
         .import_contract(&wnear_id, &mainnet)
-        .block_id(BLOCK_ID)
+        .block_height(BLOCK_HEIGHT)
         .transact()
         .await?;
 

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, convert::TryInto};
 
 use near_units::{parse_gas, parse_near};
-use workspaces::{prelude::*, DevNetwork};
+use workspaces::{prelude::*, BlockId, DevNetwork};
 use workspaces::{Account, AccountId, Contract, Network, Worker};
 
 const FT_CONTRACT_FILEPATH: &str = "./examples/res/fungible_token.wasm";
@@ -9,13 +9,17 @@ const FT_CONTRACT_FILEPATH: &str = "./examples/res/fungible_token.wasm";
 /// Contract id of ref-finance on mainnet.
 const REF_FINANCE_ACCOUNT_ID: &str = "v2.ref-finance.near";
 
+/// BlockId referencing back to a specific time just in case the contract has
+/// changed or has been updated at a later time.
+const BLOCK_ID: BlockId = BlockId::Height(50_000_000);
+
 /// Pull down the ref-finance contract and deploy it to the sandbox network,
 /// initializing it with all data required to run the tests.
 async fn create_ref(
     owner: &Account,
     worker: &Worker<impl Network + StatePatcher>,
 ) -> anyhow::Result<Contract> {
-    let mainnet = workspaces::mainnet();
+    let mainnet = workspaces::mainnet_archival();
     let ref_finance_id: AccountId = REF_FINANCE_ACCOUNT_ID.parse()?;
 
     // This will pull down the relevant ref-finance contract from mainnet. We're going
@@ -23,6 +27,7 @@ async fn create_ref(
     let ref_finance = worker
         .import_contract(&ref_finance_id, &mainnet)
         .with_initial_balance(parse_near!("1000 N"))
+        .block_id(BLOCK_ID)
         .transact()
         .await?;
 
@@ -54,10 +59,11 @@ async fn create_wnear(
     owner: &Account,
     worker: &Worker<impl Network + StatePatcher>,
 ) -> anyhow::Result<Contract> {
-    let mainnet = workspaces::mainnet();
+    let mainnet = workspaces::mainnet_archival();
     let wnear_id: AccountId = "wrap.near".to_string().try_into()?;
     let wnear = worker
         .import_contract(&wnear_id, &mainnet)
+        .block_id(BLOCK_ID)
         .transact()
         .await?;
 

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -6,7 +6,7 @@ mod worker;
 pub mod prelude;
 
 pub use network::{Account, Contract, DevNetwork, Network};
-pub use types::{AccountId, BlockId, InMemorySigner};
+pub use types::{AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
     mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_sandbox, with_testnet, Worker,
 };

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -6,5 +6,7 @@ mod worker;
 pub mod prelude;
 
 pub use network::{Account, Contract, DevNetwork, Network};
-pub use types::{AccountId, InMemorySigner};
-pub use worker::{mainnet, sandbox, testnet, with_mainnet, with_sandbox, with_testnet, Worker};
+pub use types::{AccountId, BlockId, InMemorySigner};
+pub use worker::{
+    mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_sandbox, with_testnet, Worker,
+};

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -28,6 +28,18 @@ impl Mainnet {
             },
         }
     }
+
+    pub(crate) fn archival() -> Self {
+        Self {
+            client: Client::new(ARCHIVAL_URL.into()),
+            info: Info {
+                name: "mainnet-archival".into(),
+                root_id: "near".parse().unwrap(),
+                keystore_path: PathBuf::from(".near-credentials/mainnet/"),
+                rpc_url: ARCHIVAL_URL.into(),
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -57,57 +69,6 @@ impl NetworkClient for Mainnet {
 }
 
 impl NetworkInfo for Mainnet {
-    fn info(&self) -> &Info {
-        &self.info
-    }
-}
-
-pub struct MainnetArchival {
-    client: Client,
-    info: Info,
-}
-
-impl MainnetArchival {
-    pub(crate) fn new() -> Self {
-        Self {
-            client: Client::new(ARCHIVAL_URL.into()),
-            info: Info {
-                name: "mainnet".into(),
-                root_id: "near".parse().unwrap(),
-                keystore_path: PathBuf::from(".near-credentials/mainnet/"),
-                rpc_url: ARCHIVAL_URL.into(),
-            },
-        }
-    }
-}
-
-#[async_trait]
-impl TopLevelAccountCreator for MainnetArchival {
-    async fn create_tla(
-        &self,
-        _id: AccountId,
-        _sk: SecretKey,
-    ) -> anyhow::Result<CallExecution<Account>> {
-        panic!("Archival networks do not support creating accounts");
-    }
-
-    async fn create_tla_and_deploy(
-        &self,
-        _id: AccountId,
-        _sk: SecretKey,
-        _wasm: &[u8],
-    ) -> anyhow::Result<CallExecution<Contract>> {
-        panic!("Archival networks do not support creating accounts");
-    }
-}
-
-impl NetworkClient for MainnetArchival {
-    fn client(&self) -> &Client {
-        &self.client
-    }
-}
-
-impl NetworkInfo for MainnetArchival {
     fn info(&self) -> &Info {
         &self.info
     }

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -9,6 +9,7 @@ use crate::types::{AccountId, SecretKey};
 use crate::Contract;
 
 const RPC_URL: &str = "https://rpc.mainnet.near.org";
+const ARCHIVAL_URL: &str = "https://archival-rpc.mainnet.near.org";
 
 pub struct Mainnet {
     client: Client,
@@ -56,6 +57,57 @@ impl NetworkClient for Mainnet {
 }
 
 impl NetworkInfo for Mainnet {
+    fn info(&self) -> &Info {
+        &self.info
+    }
+}
+
+pub struct MainnetArchival {
+    client: Client,
+    info: Info,
+}
+
+impl MainnetArchival {
+    pub(crate) fn new() -> Self {
+        Self {
+            client: Client::new(ARCHIVAL_URL.into()),
+            info: Info {
+                name: "mainnet".into(),
+                root_id: "near".parse().unwrap(),
+                keystore_path: PathBuf::from(".near-credentials/mainnet/"),
+                rpc_url: ARCHIVAL_URL.into(),
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl TopLevelAccountCreator for MainnetArchival {
+    async fn create_tla(
+        &self,
+        _id: AccountId,
+        _sk: SecretKey,
+    ) -> anyhow::Result<CallExecution<Account>> {
+        panic!("Archival networks do not support creating accounts");
+    }
+
+    async fn create_tla_and_deploy(
+        &self,
+        _id: AccountId,
+        _sk: SecretKey,
+        _wasm: &[u8],
+    ) -> anyhow::Result<CallExecution<Contract>> {
+        panic!("Archival networks do not support creating accounts");
+    }
+}
+
+impl NetworkClient for MainnetArchival {
+    fn client(&self) -> &Client {
+        &self.client
+    }
+}
+
+impl NetworkInfo for MainnetArchival {
     fn info(&self) -> &Info {
         &self.info
     }

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -18,7 +18,7 @@ use crate::types::{AccountId, KeyType, SecretKey};
 use crate::Worker;
 
 pub use crate::network::account::{Account, Contract};
-pub use crate::network::mainnet::Mainnet;
+pub use crate::network::mainnet::{Mainnet, MainnetArchival};
 pub use crate::network::result::{CallExecution, CallExecutionDetails, ViewResultDetails};
 pub use crate::network::sandbox::Sandbox;
 pub use crate::network::testnet::Testnet;

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -18,7 +18,7 @@ use crate::types::{AccountId, KeyType, SecretKey};
 use crate::Worker;
 
 pub use crate::network::account::{Account, Contract};
-pub use crate::network::mainnet::{Mainnet, MainnetArchival};
+pub use crate::network::mainnet::Mainnet;
 pub use crate::network::result::{CallExecution, CallExecutionDetails, ViewResultDetails};
 pub use crate::network::sandbox::Sandbox;
 pub use crate::network::testnet::Testnet;

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -1,14 +1,12 @@
 use near_crypto::KeyType;
 use near_jsonrpc_client::methods::sandbox_patch_state::RpcSandboxPatchStateRequest;
 use near_primitives::types::BlockId;
-use near_primitives::{
-    account::AccessKey, hash::CryptoHash, state_record::StateRecord, types::Balance,
-};
+use near_primitives::{account::AccessKey, state_record::StateRecord, types::Balance};
 
 use crate::network::DEV_ACCOUNT_SEED;
 use crate::rpc::client::Client;
-use crate::types::SecretKey;
-use crate::{AccountId, Contract, InMemorySigner};
+use crate::types::{BlockHeight, SecretKey};
+use crate::{AccountId, Contract, CryptoHash, InMemorySigner};
 
 pub struct ImportContractBuilder<'a, 'b> {
     account_id: AccountId,
@@ -41,8 +39,15 @@ impl<'a, 'b> ImportContractBuilder<'a, 'b> {
         }
     }
 
-    pub fn block_id(mut self, block_id: BlockId) -> Self {
-        self.block_id = Some(block_id);
+    pub fn block_height(mut self, block_height: BlockHeight) -> Self {
+        self.block_id = Some(BlockId::Height(block_height));
+        self
+    }
+
+    pub fn block_hash(mut self, block_hash: CryptoHash) -> Self {
+        self.block_id = Some(BlockId::Hash(near_primitives::hash::CryptoHash(
+            block_hash.0,
+        )));
         self
     }
 
@@ -57,13 +62,14 @@ impl<'a, 'b> ImportContractBuilder<'a, 'b> {
     }
 
     pub async fn transact(self) -> anyhow::Result<Contract> {
+        let account_id = self.account_id;
         let sk = SecretKey::from_seed(KeyType::ED25519, DEV_ACCOUNT_SEED);
         let pk = sk.public_key();
-        let signer = InMemorySigner::from_secret_key(self.account_id.clone(), sk);
+        let signer = InMemorySigner::from_secret_key(account_id.clone(), sk);
 
         let mut account_view = self
             .from_network
-            .view_account(self.account_id.clone(), self.block_id.clone())
+            .view_account(account_id.clone(), self.block_id.clone())
             .await?;
         if let Some(initial_balance) = self.initial_balance {
             account_view.amount = initial_balance;
@@ -71,23 +77,23 @@ impl<'a, 'b> ImportContractBuilder<'a, 'b> {
 
         let mut records = vec![
             StateRecord::Account {
-                account_id: self.account_id.clone(),
+                account_id: account_id.clone(),
                 account: account_view.clone().into(),
             },
             StateRecord::AccessKey {
-                account_id: self.account_id.clone(),
+                account_id: account_id.clone(),
                 public_key: pk.clone().into(),
                 access_key: AccessKey::full_access(),
             },
         ];
 
-        if account_view.code_hash != CryptoHash::default() {
+        if account_view.code_hash != near_primitives::hash::CryptoHash::default() {
             let code_view = self
                 .from_network
-                .view_code(self.account_id.clone(), self.block_id.clone())
+                .view_code(account_id.clone(), self.block_id.clone())
                 .await?;
             records.push(StateRecord::Contract {
-                account_id: self.account_id.clone(),
+                account_id: account_id.clone(),
                 code: code_view.code,
             });
         }
@@ -95,11 +101,11 @@ impl<'a, 'b> ImportContractBuilder<'a, 'b> {
         if self.import_data {
             records.extend(
                 self.from_network
-                    .view_state_raw(self.account_id.clone(), None, self.block_id.clone())
+                    .view_state_raw(account_id.clone(), None, self.block_id)
                     .await?
                     .into_iter()
                     .map(|(key, value)| StateRecord::Data {
-                        account_id: self.account_id.clone(),
+                        account_id: account_id.clone(),
                         data_key: key,
                         value,
                     }),
@@ -120,6 +126,6 @@ impl<'a, 'b> ImportContractBuilder<'a, 'b> {
             .await
             .map_err(|err| anyhow::anyhow!("Failed to patch state: {:?}", err))?;
 
-        Ok(Contract::new(self.account_id, signer))
+        Ok(Contract::new(account_id, signer))
     }
 }

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -51,7 +51,7 @@ impl<'a, 'b> ImportContractBuilder<'a, 'b> {
         self
     }
 
-    pub fn with_initial_balance(mut self, initial_balance: Balance) -> Self {
+    pub fn initial_balance(mut self, initial_balance: Balance) -> Self {
         self.initial_balance = Some(initial_balance);
         self
     }

--- a/workspaces/src/types.rs
+++ b/workspaces/src/types.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 
 pub use near_account_id::AccountId;
 pub(crate) use near_crypto::{KeyType, Signer};
+pub use near_primitives::types::BlockId;
 use serde::{Deserialize, Serialize};
 
 pub type Gas = u64;

--- a/workspaces/src/types.rs
+++ b/workspaces/src/types.rs
@@ -1,11 +1,12 @@
 /// Types copied over from near_primitives since those APIs are not yet stable.
 /// and internal libraries like near-jsonrpc-client requires specific versions
 /// of these types which shouldn't be exposed either.
+use std::convert::TryFrom;
 use std::path::Path;
 
 pub use near_account_id::AccountId;
 pub(crate) use near_crypto::{KeyType, Signer};
-pub use near_primitives::types::BlockId;
+use near_primitives::serialize::from_base;
 use serde::{Deserialize, Serialize};
 
 pub type Gas = u64;
@@ -13,6 +14,9 @@ pub type Gas = u64;
 /// Balance is type for storing amounts of tokens. Usually represents the amount of tokens
 /// in yoctoNear (1e-24).
 pub type Balance = u128;
+
+/// Height of a specific block
+pub type BlockHeight = u64;
 
 impl From<PublicKey> for near_crypto::PublicKey {
     fn from(pk: PublicKey) -> Self {
@@ -53,5 +57,39 @@ impl InMemorySigner {
 
     pub(crate) fn inner(&self) -> &near_crypto::InMemorySigner {
         &self.0
+    }
+}
+
+// type taken from near_primitives::hash::CryptoHash.
+/// CryptoHash is type for storing the hash of a specific block.
+pub struct CryptoHash(pub [u8; 32]);
+
+impl std::str::FromStr for CryptoHash {
+    type Err = Box<dyn std::error::Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let bytes = from_base(s).map_err::<Self::Err, _>(|e| e.to_string().into())?;
+        Self::try_from(bytes)
+    }
+}
+
+impl TryFrom<&[u8]> for CryptoHash {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(bytes: &[u8]) -> Result<Self, Self::Error> {
+        if bytes.len() != 32 {
+            return Err("incorrect length for hash".into());
+        }
+        let mut buf = [0; 32];
+        buf.copy_from_slice(bytes);
+        Ok(CryptoHash(buf))
+    }
+}
+
+impl TryFrom<Vec<u8>> for CryptoHash {
+    type Error = Box<dyn std::error::Error>;
+
+    fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
+        <Self as TryFrom<&[u8]>>::try_from(v.as_ref())
     }
 }

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -2,7 +2,7 @@ mod impls;
 
 use std::sync::Arc;
 
-use crate::network::{Mainnet, Network, Sandbox, Testnet};
+use crate::network::{Mainnet, MainnetArchival, Network, Sandbox, Testnet};
 
 pub struct Worker<T> {
     workspace: Arc<T>,
@@ -29,6 +29,10 @@ pub fn testnet() -> Worker<Testnet> {
 
 pub fn mainnet() -> Worker<Mainnet> {
     Worker::new(Mainnet::new())
+}
+
+pub fn mainnet_archival() -> Worker<MainnetArchival> {
+    Worker::new(MainnetArchival::new())
 }
 
 pub async fn with_sandbox<F, T>(task: F) -> T::Output

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -2,7 +2,7 @@ mod impls;
 
 use std::sync::Arc;
 
-use crate::network::{Mainnet, MainnetArchival, Network, Sandbox, Testnet};
+use crate::network::{Mainnet, Network, Sandbox, Testnet};
 
 pub struct Worker<T> {
     workspace: Arc<T>,
@@ -31,8 +31,8 @@ pub fn mainnet() -> Worker<Mainnet> {
     Worker::new(Mainnet::new())
 }
 
-pub fn mainnet_archival() -> Worker<MainnetArchival> {
-    Worker::new(MainnetArchival::new())
+pub fn mainnet_archival() -> Worker<Mainnet> {
+    Worker::new(Mainnet::archival())
 }
 
 pub async fn with_sandbox<F, T>(task: F) -> T::Output

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -1,3 +1,6 @@
+// Required since `test_log` adds more recursion than the standard recursion limit of 128
+#![recursion_limit = "256"]
+
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use serde_json::json;
 use test_log::test;


### PR DESCRIPTION
This will fix the issue with https://github.com/near/workspaces-rs/issues/49. This was because ref-finance contract on mainnet on updated and so did some deposit requirements get upped. With this PR, to remedy the issue, mainnet archival rpc was added so we can grab the contract from a specific block height instead of the latest block height