### PR TITLE
Added `is_success` / `is_failure` for CallExecution results

### DIFF
--- a/workspaces/src/network/result.rs
+++ b/workspaces/src/network/result.rs
@@ -18,6 +18,18 @@ impl<T> CallExecution<T> {
     pub fn into_result(self) -> anyhow::Result<T> {
         Into::<anyhow::Result<_>>::into(self)
     }
+
+    /// Checks whether the transaction was successful. Returns true if
+    /// `details.status` is FinalExecutionStatus::Success.
+    pub fn is_success(&self) -> bool {
+        matches!(self.details.status, FinalExecutionStatus::SuccessValue(_))
+    }
+
+    /// Checks whether the transaction has failed. Returns true if
+    /// `details.status` is FinalExecutionStatus::Success.
+    pub fn is_failure(&self) -> bool {
+        matches!(self.details.status, FinalExecutionStatus::Failure(_))
+    }
 }
 
 impl<T> From<CallExecution<T>> for anyhow::Result<T> {

--- a/workspaces/src/network/result.rs
+++ b/workspaces/src/network/result.rs
@@ -26,7 +26,7 @@ impl<T> CallExecution<T> {
     }
 
     /// Checks whether the transaction has failed. Returns true if
-    /// `details.status` is FinalExecutionStatus::Success.
+    /// `details.status` is FinalExecutionStatus::Failure.
     pub fn is_failure(&self) -> bool {
         matches!(self.details.status, FinalExecutionStatus::Failure(_))
     }


### PR DESCRIPTION
Convenient functions (namely `is_success` and `is_faulure`) for easy assertions discussed in https://github.com/near/near-sdk-rs/pull/699#discussion_r786181686