### PR TITLE
release: 0.1.1

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -30,7 +30,7 @@ near-crypto = "0.5"
 near-primitives = "0.5"
 near-jsonrpc-primitives = "0.5"
 near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
-near-sandbox-utils = "0.1"
+near-sandbox-utils = "0.1.1"
 
 [build-dependencies]
 near-sandbox-utils = "0.1"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspaces"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/near/workspaces-rs"


### PR DESCRIPTION
Cutting a patch version release on top of https://github.com/near/workspaces-rs/pull/46 so that it doesn't stall CI for some projects like `near-sdk-rs`. This won't have any API breaking changes, so should be fine making this a patch version release