### PR TITLE
fix: Make `access_key` do an optimistic RPC query

### DIFF
--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -293,7 +293,7 @@ pub(crate) async fn access_key(
 ) -> anyhow::Result<(AccessKeyView, CryptoHash)> {
     let query_resp = client
         .query(&methods::query::RpcQueryRequest {
-            block_reference: Finality::Final.into(),
+            block_reference: Finality::None.into(),
             request: QueryRequest::ViewAccessKey {
                 account_id,
                 public_key,


### PR DESCRIPTION
This PR aligns `access_key` to behave like all other view queries and make an optimistic (finality-wise) RPC query. This is especially important since `access_key` is also used to make function call transactions, so if you make many calls in a quick succession this can lead to duplicate access key nonces being returned by `access_key`.