### PR TITLE
feat: add rpc logging

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -26,11 +26,11 @@ tokio-retry = "0.3"
 tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
 
-near-account-id = "0.5"
-near-crypto = "0.5"
-near-primitives = "0.5"
-near-jsonrpc-primitives = "0.5"
-near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
+near-account-id = "0.12.0"
+near-crypto = "0.12.0"
+near-primitives = "0.12.0"
+near-jsonrpc-primitives = "0.12.0"
+near-jsonrpc-client = { version = "0.3.0", features = ["sandbox"] }
 near-sandbox-utils = "0.1.1"
 
 [build-dependencies]

--- a/workspaces/tests/create_account.rs
+++ b/workspaces/tests/create_account.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use test_log::test;
 use workspaces::prelude::*;
 

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -1,3 +1,4 @@
+#![recursion_limit = "256"]
 use serde::{Deserialize, Serialize};
 use test_log::test;
 use workspaces::prelude::*;


### PR DESCRIPTION
This PR adds logging to RPC client. I made the logs dynamic depending on the logging level enabled. Usually `INFO` would be enough for most users as it prints one-liners with submitted actions and the resulting status. But if a user wants more information (e.g. gas profile, logs etc), they can enable `DEBUG`. Try it out by running tests with `RUST_LOG=workspaces=info`.