### PR TITLE
refactor: change patch state parameters to be slices

### DIFF
--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -99,8 +99,8 @@ async fn main() -> anyhow::Result<()> {
     worker
         .patch_state(
             sandbox_contract.id(),
-            "STATE".into(),
-            status_msg.try_to_vec()?,
+            "STATE".as_bytes(),
+            &status_msg.try_to_vec()?,
         )
         .await?;
 

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -101,8 +101,8 @@ pub trait StatePatcher {
     async fn patch_state(
         &self,
         contract_id: &AccountId,
-        key: Vec<u8>,
-        value: Vec<u8>,
+        key: &[u8],
+        value: &[u8],
     ) -> anyhow::Result<()>;
 
     fn import_contract<'a, 'b>(
@@ -120,13 +120,13 @@ where
     async fn patch_state(
         &self,
         contract_id: &AccountId,
-        key: Vec<u8>,
-        value: Vec<u8>,
+        key: &[u8],
+        value: &[u8],
     ) -> anyhow::Result<()> {
         let state = StateRecord::Data {
             account_id: contract_id.to_owned(),
-            data_key: key,
-            value,
+            data_key: key.to_vec(),
+            value: value.to_vec(),
         };
         let records = vec![state];
 

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -64,8 +64,8 @@ where
     async fn patch_state(
         &self,
         contract_id: &AccountId,
-        key: Vec<u8>,
-        value: Vec<u8>,
+        key: &[u8],
+        value: &[u8],
     ) -> anyhow::Result<()> {
         self.workspace.patch_state(contract_id, key, value).await
     }

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -71,7 +71,7 @@ async fn test_patch_state() -> anyhow::Result<()> {
     });
 
     worker
-        .patch_state(&contract_id, "STATE".into(), status_msg.try_to_vec()?)
+        .patch_state(&contract_id, "STATE".as_bytes(), &status_msg.try_to_vec()?)
         .await?;
 
     let status: String = worker


### PR DESCRIPTION
In the end, I had to copy the slices into vectors anyway, not sure if there is a way to avoid that