### PR TITLE
chore: Add view_account, view_code, view_block

### DIFF
--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -5,7 +5,7 @@ mod worker;
 
 pub mod prelude;
 
-pub use network::{Account, Contract, DevNetwork, Network};
+pub use network::{Account, AccountDetails, Contract, DevNetwork, Network};
 pub use types::{AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
     mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_sandbox, with_testnet, Worker,

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -5,7 +5,7 @@ mod worker;
 
 pub mod prelude;
 
-pub use network::{Account, AccountDetails, Contract, DevNetwork, Network};
+pub use network::{Account, AccountDetails, Block, Contract, DevNetwork, Network};
 pub use types::{AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
     mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_sandbox, with_testnet, Worker,

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -339,9 +339,10 @@ where
 
 /// Details of an Account or Contract. This is an non-exhaustive list of items
 /// that the account stores in the blockchain state.
+#[derive(Debug, PartialEq)]
 #[non_exhaustive]
 pub struct AccountDetails {
-    pub amount: Balance,
+    pub balance: Balance,
     pub locked: Balance,
     pub code_hash: CryptoHash,
     pub storage_usage: u64,
@@ -350,7 +351,7 @@ pub struct AccountDetails {
 impl From<AccountView> for AccountDetails {
     fn from(account: AccountView) -> Self {
         Self {
-            amount: account.amount,
+            balance: account.amount,
             locked: account.locked,
             code_hash: CryptoHash(account.code_hash.0),
             storage_usage: account.storage_usage,

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -77,7 +77,7 @@ impl Account {
     }
 
     /// Views the current account's details such as balance and storage usage.
-    pub async fn viwe_account<T: Network>(
+    pub async fn view_account<T: Network>(
         &self,
         worker: &Worker<T>,
     ) -> anyhow::Result<AccountDetails> {

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -171,6 +171,11 @@ impl Contract {
         worker.view(self.id(), function, args).await
     }
 
+    /// View the WASM code bytes of this contract.
+    pub async fn view_code<T: Network>(&self, worker: &Worker<T>) -> anyhow::Result<Vec<u8>> {
+        worker.view_code(self.id()).await
+    }
+
     /// Views the current contract's details such as balance and storage usage.
     pub async fn details<T: Network>(&self, worker: &Worker<T>) -> anyhow::Result<AccountDetails> {
         worker.view_account(self.id()).await

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -77,7 +77,10 @@ impl Account {
     }
 
     /// Views the current account's details such as balance and storage usage.
-    pub async fn details<T: Network>(&self, worker: &Worker<T>) -> anyhow::Result<AccountDetails> {
+    pub async fn viwe_account<T: Network>(
+        &self,
+        worker: &Worker<T>,
+    ) -> anyhow::Result<AccountDetails> {
         worker.view_account(&self.id).await
     }
 
@@ -177,7 +180,10 @@ impl Contract {
     }
 
     /// Views the current contract's details such as balance and storage usage.
-    pub async fn details<T: Network>(&self, worker: &Worker<T>) -> anyhow::Result<AccountDetails> {
+    pub async fn view_account<T: Network>(
+        &self,
+        worker: &Worker<T>,
+    ) -> anyhow::Result<AccountDetails> {
         worker.view_account(self.id()).await
     }
 

--- a/workspaces/src/network/block.rs
+++ b/workspaces/src/network/block.rs
@@ -3,6 +3,7 @@ use near_primitives::views::{BlockHeaderView, BlockView};
 use crate::{BlockHeight, CryptoHash};
 
 /// Struct containing information on block coming from the network
+#[derive(Debug, PartialEq)]
 pub struct Block {
     header: BlockHeader,
 }
@@ -31,7 +32,7 @@ impl Block {
 
 /// The block header info. This is a non-exhaustive list of items that
 /// could be present in a block header. More can be added in the future.
-#[non_exhaustive]
+#[derive(Debug, PartialEq)]
 struct BlockHeader {
     height: BlockHeight,
     epoch_id: CryptoHash,

--- a/workspaces/src/network/block.rs
+++ b/workspaces/src/network/block.rs
@@ -1,0 +1,57 @@
+use near_primitives::views::{BlockHeaderView, BlockView};
+
+use crate::{BlockHeight, CryptoHash};
+
+/// Struct containing information on block coming from the network
+pub struct Block {
+    header: BlockHeader,
+}
+
+impl Block {
+    /// The block timestamp in nanoseconds.
+    fn timestamp(&self) -> u64 {
+        self.header.timestamp_nanosec
+    }
+
+    /// Current height of this block.
+    fn height(&self) -> BlockHeight {
+        self.header.height
+    }
+
+    fn hash(&self) -> &CryptoHash {
+        &self.header.hash
+    }
+
+    fn epoch_id(&self) -> &CryptoHash {
+        &self.header.epoch_id
+    }
+}
+
+/// The block header info. This is a non-exhaustive list of items that
+/// could be present in a block header. More can be added in the future.
+#[non_exhaustive]
+struct BlockHeader {
+    height: BlockHeight,
+    epoch_id: CryptoHash,
+    hash: CryptoHash,
+    timestamp_nanosec: u64,
+}
+
+impl From<BlockView> for Block {
+    fn from(block_view: BlockView) -> Self {
+        Self {
+            header: block_view.header.into(),
+        }
+    }
+}
+
+impl From<BlockHeaderView> for BlockHeader {
+    fn from(header_view: BlockHeaderView) -> Self {
+        Self {
+            height: header_view.height,
+            epoch_id: CryptoHash(header_view.epoch_id.0),
+            hash: CryptoHash(header_view.hash.0),
+            timestamp_nanosec: header_view.timestamp_nanosec,
+        }
+    }
+}

--- a/workspaces/src/network/block.rs
+++ b/workspaces/src/network/block.rs
@@ -9,20 +9,22 @@ pub struct Block {
 
 impl Block {
     /// The block timestamp in nanoseconds.
-    fn timestamp(&self) -> u64 {
+    pub fn timestamp(&self) -> u64 {
         self.header.timestamp_nanosec
     }
 
     /// Current height of this block.
-    fn height(&self) -> BlockHeight {
+    pub fn height(&self) -> BlockHeight {
         self.header.height
     }
 
-    fn hash(&self) -> &CryptoHash {
+    /// The hash of the block itself.
+    pub fn hash(&self) -> &CryptoHash {
         &self.header.hash
     }
 
-    fn epoch_id(&self) -> &CryptoHash {
+    /// The id of an epoch this block belongs to.
+    pub fn epoch_id(&self) -> &CryptoHash {
         &self.header.epoch_id
     }
 }

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -1,4 +1,5 @@
 mod account;
+mod block;
 mod info;
 mod mainnet;
 mod result;
@@ -18,6 +19,7 @@ use crate::types::{AccountId, KeyType, SecretKey};
 use crate::Worker;
 
 pub use crate::network::account::{Account, AccountDetails, Contract};
+pub use crate::network::block::Block;
 pub use crate::network::mainnet::Mainnet;
 pub use crate::network::result::{CallExecution, CallExecutionDetails, ViewResultDetails};
 pub use crate::network::sandbox::Sandbox;

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -17,7 +17,7 @@ use crate::rpc::patch::ImportContractBuilder;
 use crate::types::{AccountId, KeyType, SecretKey};
 use crate::Worker;
 
-pub use crate::network::account::{Account, Contract};
+pub use crate::network::account::{Account, AccountDetails, Contract};
 pub use crate::network::mainnet::Mainnet;
 pub use crate::network::result::{CallExecution, CallExecutionDetails, ViewResultDetails};
 pub use crate::network::sandbox::Sandbox;

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -15,7 +15,8 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::{Balance, BlockId, Finality, Gas, StoreKey};
 use near_primitives::views::{
-    AccessKeyView, AccountView, ContractCodeView, FinalExecutionOutcomeView, QueryRequest,
+    AccessKeyView, AccountView, BlockView, ContractCodeView, FinalExecutionOutcomeView,
+    QueryRequest,
 };
 
 use crate::network::ViewResultDetails;
@@ -236,6 +237,18 @@ impl Client {
             QueryResponseKind::ViewCode(code) => Ok(code),
             _ => anyhow::bail!(ERR_INVALID_VARIANT),
         }
+    }
+
+    pub(crate) async fn view_block(&self, block_id: Option<BlockId>) -> anyhow::Result<BlockView> {
+        let block_reference = block_id
+            .map(Into::into)
+            .unwrap_or_else(|| Finality::None.into());
+
+        let block_view = self
+            .query(&methods::block::RpcBlockRequest { block_reference })
+            .await?;
+
+        Ok(block_view)
     }
 
     pub(crate) async fn deploy(

--- a/workspaces/src/types.rs
+++ b/workspaces/src/types.rs
@@ -64,7 +64,7 @@ impl InMemorySigner {
 
 // type taken from near_primitives::hash::CryptoHash.
 /// CryptoHash is type for storing the hash of a specific block.
-#[derive(PartialEq)]
+#[derive(Hash, PartialEq)]
 pub struct CryptoHash(pub [u8; 32]);
 
 impl std::str::FromStr for CryptoHash {

--- a/workspaces/src/types.rs
+++ b/workspaces/src/types.rs
@@ -2,11 +2,13 @@
 /// and internal libraries like near-jsonrpc-client requires specific versions
 /// of these types which shouldn't be exposed either.
 use std::convert::TryFrom;
+use std::fmt;
 use std::path::Path;
 
 pub use near_account_id::AccountId;
 pub(crate) use near_crypto::{KeyType, Signer};
-use near_primitives::serialize::from_base;
+use near_primitives::logging::pretty_hash;
+use near_primitives::serialize::{from_base, to_base};
 use serde::{Deserialize, Serialize};
 
 pub type Gas = u64;
@@ -62,6 +64,7 @@ impl InMemorySigner {
 
 // type taken from near_primitives::hash::CryptoHash.
 /// CryptoHash is type for storing the hash of a specific block.
+#[derive(PartialEq)]
 pub struct CryptoHash(pub [u8; 32]);
 
 impl std::str::FromStr for CryptoHash {
@@ -91,5 +94,17 @@ impl TryFrom<Vec<u8>> for CryptoHash {
 
     fn try_from(v: Vec<u8>) -> Result<Self, Self::Error> {
         <Self as TryFrom<&[u8]>>::try_from(v.as_ref())
+    }
+}
+
+impl fmt::Debug for CryptoHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", pretty_hash(&self.to_string()))
+    }
+}
+
+impl fmt::Display for CryptoHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&to_base(&self.0), f)
     }
 }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -87,6 +87,7 @@ where
         self.workspace.client()
     }
 
+    /// Call into a contract's change function.
     pub async fn call(
         &self,
         contract: &Contract,
@@ -108,6 +109,7 @@ where
             .map(Into::into)
     }
 
+    /// Call into a contract's view function.
     pub async fn view(
         &self,
         contract_id: &AccountId,
@@ -125,6 +127,9 @@ where
         Ok(code_view.code)
     }
 
+    /// View the state of a account/contract on the network. This will return the internal
+    /// state of the account in the form of a map of key-value pairs; where STATE contains
+    /// info on a contract's internal data.
     pub async fn view_state(
         &self,
         contract_id: &AccountId,
@@ -133,10 +138,13 @@ where
         self.client().view_state(contract_id.clone(), prefix).await
     }
 
+    /// View the latest block from the network
     pub async fn view_latest_block(&self) -> anyhow::Result<Block> {
         self.client().view_block(None).await.map(Into::into)
     }
 
+    /// Transfer tokens from one account to another. The signer is the account
+    /// that will be used to to send from.
     pub async fn transfer_near(
         &self,
         signer: &InMemorySigner,
@@ -149,6 +157,8 @@ where
             .map(Into::into)
     }
 
+    /// Deletes an account from the network. The beneficiary will receive the balance
+    /// of the account deleted.
     pub async fn delete_account(
         &self,
         account_id: &AccountId,
@@ -161,6 +171,7 @@ where
             .map(Into::into)
     }
 
+    /// View account details of a specific account on the network.
     pub async fn view_account(&self, account_id: &AccountId) -> anyhow::Result<AccountDetails> {
         self.client()
             .view_account(account_id.clone(), None)

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -12,7 +12,7 @@ use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractBuilder;
 use crate::types::{AccountId, Gas, InMemorySigner, SecretKey};
 use crate::worker::Worker;
-use crate::Network;
+use crate::{Network, AccountDetails};
 
 impl<T> Clone for Worker<T> {
     fn clone(&self) -> Self {
@@ -147,6 +147,13 @@ where
     ) -> anyhow::Result<CallExecutionDetails> {
         self.client()
             .delete_account(signer, account_id, beneficiary_id)
+            .await
+            .map(Into::into)
+    }
+
+    pub async fn view_account(&self, account_id: &AccountId) -> anyhow::Result<AccountDetails> {
+        self.client()
+            .view_account(account_id.clone(), None)
             .await
             .map(Into::into)
     }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -12,7 +12,7 @@ use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractBuilder;
 use crate::types::{AccountId, Gas, InMemorySigner, SecretKey};
 use crate::worker::Worker;
-use crate::{Network, AccountDetails};
+use crate::{AccountDetails, Network};
 
 impl<T> Clone for Worker<T> {
     fn clone(&self) -> Self {
@@ -117,6 +117,12 @@ where
         self.client()
             .view(contract_id.clone(), function.into(), args)
             .await
+    }
+
+    /// View the WASM code bytes of a contract on the network.
+    pub async fn view_code(&self, contract_id: &AccountId) -> anyhow::Result<Vec<u8>> {
+        let code_view = self.client().view_code(contract_id.clone(), None).await?;
+        Ok(code_view.code)
     }
 
     pub async fn view_state(

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use near_primitives::types::{Balance, StoreKey};
 
 use crate::network::{
-    Account, AllowDevAccountCreation, CallExecution, CallExecutionDetails, Contract, NetworkClient,
-    NetworkInfo, StatePatcher, TopLevelAccountCreator, ViewResultDetails,
+    Account, AllowDevAccountCreation, Block, CallExecution, CallExecutionDetails, Contract,
+    NetworkClient, NetworkInfo, StatePatcher, TopLevelAccountCreator, ViewResultDetails,
 };
 use crate::network::{Info, Sandbox};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
@@ -131,6 +131,10 @@ where
         prefix: Option<StoreKey>,
     ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
         self.client().view_state(contract_id.clone(), prefix).await
+    }
+
+    pub async fn view_latest_block(&self) -> anyhow::Result<Block> {
+        self.client().view_block(None).await.map(Into::into)
     }
 
     pub async fn transfer_near(


### PR DESCRIPTION
This adds a couple convenience functions to `Worker` and `Account` types:
- view_account: stuff like balance and storage usage
- view_code
- view_block: to grab latest block timestamps

Also addresses https://github.com/near/workspaces-rs/issues/76
