### PR TITLE
feat: improve error handling on failed transactions

### DIFF
--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -242,7 +242,7 @@ impl<'a, T: Network> CallBuilder<'a, T> {
                 self.deposit,
             )
             .await
-            .map(Into::into)
+            .and_then(CallExecutionDetails::from_outcome)
     }
 
     pub async fn view(self) -> anyhow::Result<ViewResultDetails> {

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -105,7 +105,7 @@ where
                 deposit.unwrap_or(DEFAULT_CALL_DEPOSIT),
             )
             .await
-            .map(Into::into)
+            .and_then(CallExecutionDetails::from_outcome)
     }
 
     pub async fn view(
@@ -136,7 +136,7 @@ where
         self.client()
             .transfer_near(signer, receiver_id, amount_yocto)
             .await
-            .map(Into::into)
+            .and_then(CallExecutionDetails::from_outcome)
     }
 
     pub async fn delete_account(
@@ -148,7 +148,7 @@ where
         self.client()
             .delete_account(signer, account_id, beneficiary_id)
             .await
-            .map(Into::into)
+            .and_then(CallExecutionDetails::from_outcome)
     }
 }
 


### PR DESCRIPTION
This PR improves error handling on failed transactions and will force the user to handle the error now as an anyhow result. For instance, before this PR, the following would just dangle with the status object returned being ignored at the end.
```
contract.call(function_name)
   .args(...)
   .transact()
   .await?;
```
And after this PR, the `?` error forward at the end will trigger an error on failed transactions. This improves propagating errors such as invalid arguments to calling into a contract function
