### PR TITLE
chore: suppress sandbox bin logs

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -31,10 +31,10 @@ near-crypto = "0.5"
 near-primitives = "0.5"
 near-jsonrpc-primitives = "0.5"
 near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
-near-sandbox-utils = "0.1.1"
+near-sandbox-utils = { path = "../../sandbox/crate/" }
 
 [build-dependencies]
-near-sandbox-utils = "0.1"
+near-sandbox-utils = { path = "../../sandbox/crate/" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -31,10 +31,10 @@ near-crypto = "0.5"
 near-primitives = "0.5"
 near-jsonrpc-primitives = "0.5"
 near-jsonrpc-client = { version = "0.1", features = ["sandbox"] }
-near-sandbox-utils = { path = "../../sandbox/crate/" }
+near-sandbox-utils = "0.1.2"
 
 [build-dependencies]
-near-sandbox-utils = { path = "../../sandbox/crate/" }
+near-sandbox-utils = "0.1.2"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -77,10 +77,9 @@ impl Drop for SandboxServer {
 /// will be forward into RUST_LOG environment variable as to not conflict
 /// with similar named log targets.
 fn supress_sandbox_logs_if_required() {
-    match std::env::var("NEAR_ENABLE_SANDBOX_LOG") {
-        Ok(val) if val == "on" => {}
+    if let Err(_) = std::env::var("NEAR_ENABLE_SANDBOX_LOG") {
         // non-exhaustive list of targets to supress, since choosing a default LogLevel
         // does nothing in this case, since nearcore seems to be overriding it somehow:
-        _ => std::env::set_var("NEAR_SANDBOX_LOG", "near=error,stats=error,network=error"),
+        std::env::set_var("NEAR_SANDBOX_LOG", "near=error,stats=error,network=error");
     };
 }

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -72,14 +72,18 @@ impl Drop for SandboxServer {
 }
 
 /// Turn off neard-sandbox logs by default. Users can turn them back on with
-/// NEAR_ENABLE_SANDBOX_LOG=on and specify further paramters with the custom
+/// NEAR_ENABLE_SANDBOX_LOG=1 and specify further paramters with the custom
 /// NEAR_SANDBOX_LOG for higher levels of specificity. NEAR_SANDBOX_LOG args
 /// will be forward into RUST_LOG environment variable as to not conflict
 /// with similar named log targets.
 fn supress_sandbox_logs_if_required() {
-    if let Err(_) = std::env::var("NEAR_ENABLE_SANDBOX_LOG") {
-        // non-exhaustive list of targets to supress, since choosing a default LogLevel
-        // does nothing in this case, since nearcore seems to be overriding it somehow:
-        std::env::set_var("NEAR_SANDBOX_LOG", "near=error,stats=error,network=error");
-    };
+    if let Ok(val) = std::env::var("NEAR_ENABLE_SANDBOX_LOG") {
+        if val != "0" {
+            return;
+        }
+    }
+
+    // non-exhaustive list of targets to supress, since choosing a default LogLevel
+    // does nothing in this case, since nearcore seems to be overriding it somehow:
+    std::env::set_var("NEAR_SANDBOX_LOG", "near=error,stats=error,network=error");
 }

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -78,9 +78,9 @@ impl Drop for SandboxServer {
 /// with similar named log targets.
 fn supress_sandbox_logs_if_required() {
     match std::env::var("NEAR_ENABLE_SANDBOX_LOG") {
-        Ok(val) if val == "on" => {},
+        Ok(val) if val == "on" => {}
         // non-exhaustive list of targets to supress, since choosing a default LogLevel
         // does nothing in this case, since nearcore seems to be overriding it somehow:
-        _ => std::env::set_var("NEAR_SANDBOX_LOG", "near=error,stats=error,network=error")
+        _ => std::env::set_var("NEAR_SANDBOX_LOG", "near=error,stats=error,network=error"),
     };
 }


### PR DESCRIPTION
This suppresses all sandbox logs and allows the user to control it via an environment variable