### PR TITLE
fix resolution of relative paths when compiling contracts

### DIFF
--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -142,13 +142,13 @@ impl<P: AsRef<Path>> __ContractCompiler<P> {
 ///
 /// - Relative paths:
 ///
-///   ```no_run
+///   ```ignore
 ///   let wasm = compile_contract!("../../contract");
 ///   ```
 ///
 /// - Absolute paths:
 ///
-///   ```no_run
+///   ```ignore
 ///   let wasm = compile_contract!("/workspace/contract");
 ///   ```
 fn resolve_path<P: AsRef<Path>>(caller: &Path, contract_path: P) -> anyhow::Result<PathBuf> {

--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -3,8 +3,7 @@ use async_process::Command;
 use cargo_metadata::{Message, Metadata, MetadataCommand};
 use std::env;
 use std::fmt::Debug;
-use std::fs;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use std::process::Stdio;
 use tracing::debug;
 
@@ -64,38 +63,156 @@ async fn build_cargo_project<P: AsRef<Path> + Debug>(
 
 /// Builds the cargo project located at `project_path` and returns the generated wasm file contents.
 ///
-/// NOTE: This function does not check whether the resulting wasm file is a valid smart
+/// NOTE: This macro does not check whether the resulting wasm file is a valid smart
 /// contract or not.
-pub async fn compile_project(project_path: &str) -> anyhow::Result<Vec<u8>> {
-    let messages = build_cargo_project(fs::canonicalize(project_path)?).await?;
-    // We find the last compiler artifact message which should contain information about the
-    // resulting .wasm file
-    let compile_artifact = messages
-        .iter()
-        .filter_map(|m| match m {
-            cargo_metadata::Message::CompilerArtifact(artifact) => Some(artifact),
-            _ => None,
-        })
-        .last()
-        .ok_or(anyhow!(
-            "Cargo failed to produce any compilation artifacts. \
-                 Please check that your project contains a NEAR smart contract."
-        ))?;
-    // The project could have generated many auxiliary files, we are only interested in .wasm files
-    let wasm_files = compile_artifact
-        .filenames
-        .iter()
-        .filter(|f| f.as_str().ends_with(".wasm"))
-        .collect::<Vec<_>>();
-    match wasm_files.as_slice() {
-        [] => Err(anyhow!(
-            "Compilation resulted in no '.wasm' target files. \
-                 Please check that your project contains a NEAR smart contract."
-        )),
-        [file] => Ok(tokio::fs::read(file.canonicalize()?).await?),
-        _ => Err(anyhow!(
-            "Compilation resulted in more than one '.wasm' target file: {:?}",
-            wasm_files
-        )),
+#[macro_export]
+macro_rules! compile_contract {
+    ($contract_path:expr) => {
+        $crate::__ContractCompiler::__new_dont_call_manually(file!(), $contract_path).compile()
+    };
+}
+
+#[doc(hidden)]
+pub struct __ContractCompiler<P> {
+    caller: &'static str,
+    project_path: P,
+}
+
+impl<P: AsRef<Path>> __ContractCompiler<P> {
+    // this is aptly named to induce friction, this structure should not be constructed trivially.
+    pub fn __new_dont_call_manually(caller: &'static str, project_path: P) -> Self {
+        Self {
+            caller,
+            project_path,
+        }
     }
+
+    pub async fn compile(self) -> anyhow::Result<Vec<u8>> {
+        let contract_path = resolve_path(Path::new(self.caller), self.project_path)?;
+
+        let messages = build_cargo_project(contract_path).await?;
+        // We find the last compiler artifact message which should contain information about the
+        // resulting .wasm file
+        let compile_artifact = messages
+            .iter()
+            .filter_map(|m| match m {
+                cargo_metadata::Message::CompilerArtifact(artifact) => Some(artifact),
+                _ => None,
+            })
+            .last()
+            .ok_or(anyhow!(
+                "Cargo failed to produce any compilation artifacts. \
+                     Please check that your project contains a NEAR smart contract."
+            ))?;
+        // The project could have generated many auxiliary files, we are only interested in .wasm files
+        let wasm_files = compile_artifact
+            .filenames
+            .iter()
+            .filter(|f| f.as_str().ends_with(".wasm"))
+            .collect::<Vec<_>>();
+        match wasm_files.as_slice() {
+            [] => Err(anyhow!(
+                "Compilation resulted in no '.wasm' target files. \
+                     Please check that your project contains a NEAR smart contract."
+            )),
+            [file] => Ok(tokio::fs::read(file.canonicalize()?).await?),
+            _ => Err(anyhow!(
+                "Compilation resulted in more than one '.wasm' target file: {:?}",
+                wasm_files
+            )),
+        }
+    }
+}
+
+/// Resolves paths, relative or absolute, regardless of file existence.
+///
+/// Assuming this workspace tree for our cargo project structure:
+///
+/// ```txt
+///  /workspace
+///  ├── project
+///  │   └── src
+///  │       └── lib.rs
+///  └── contract
+///      └── src
+///          └── lib.rs
+/// ```
+///
+/// Then we can link to our contract from _`/workspace/project/src/lib.rs`_ using either of these methods:
+///
+/// - Relative paths:
+///
+///   ```no_run
+///   let wasm = compile_contract!("../../contract");
+///   ```
+///
+/// - Absolute paths:
+///
+///   ```no_run
+///   let wasm = compile_contract!("/workspace/contract");
+///   ```
+fn resolve_path<P: AsRef<Path>>(caller: &Path, contract_path: P) -> anyhow::Result<PathBuf> {
+    let contract_path = match contract_path.as_ref() {
+        // if "/workspace/contract", return as-is
+        contract_path if contract_path.is_absolute() => contract_path.to_path_buf(),
+        contract_path => {
+            // if "../../contract";
+            let workspace = root_cargo_metadata()?;
+            let mut dir = None;
+            for pkg in workspace.packages {
+                if !workspace.workspace_members.contains(&pkg.id) {
+                    continue;
+                }
+                if let (Some(caller), Some(crate_path)) =
+                    (caller.parent(), pkg.manifest_path.parent())
+                {
+                    // caller's parent: `project/src`
+                    // crate_path: `/workspace/project`
+                    if let Ok(this_path) = crate_path
+                        .strip_prefix(&workspace.workspace_root)
+                        .and_then(|crate_path| caller.strip_prefix(crate_path))
+                    {
+                        // crate_path (after stripping workspace root): `project`
+                        // caller's parent after stripping crate_path: `src`
+                        dir.replace(this_path);
+                    }
+                }
+            }
+            // joined: `src/../../contract` (as seen from /workspace/project)
+            dir.ok_or_else(|| anyhow::anyhow!("expected a cargo directory structure"))?
+                .join(contract_path)
+        }
+    };
+    // normalized: `/workspace/contract`
+    Ok(normalize_path(&contract_path))
+}
+
+/// Normalize a path, removing things like `.` and `..`.
+///
+/// Adapted from [`cargo-util`](https://github.com/rust-lang/cargo/blob/65c82664263feddc5fe2d424be0993c28d46377a/crates/cargo-util/src/paths.rs#L81).
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = path.components().peekable();
+    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
+        components.next();
+        PathBuf::from(c.as_os_str())
+    } else {
+        PathBuf::new()
+    };
+
+    for component in components {
+        match component {
+            Component::Prefix(..) => unreachable!(),
+            Component::RootDir => {
+                ret.push(component.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                ret.pop();
+            }
+            Component::Normal(c) => {
+                ret.push(c);
+            }
+        }
+    }
+    ret
 }

--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -61,6 +61,40 @@ async fn build_cargo_project<P: AsRef<Path> + Debug>(
     }
 }
 
+async fn compile_project(project_path: &Path) -> anyhow::Result<Vec<u8>> {
+    let messages = build_cargo_project(project_path).await?;
+    // We find the last compiler artifact message which should contain information about the
+    // resulting .wasm file
+    let compile_artifact = messages
+        .iter()
+        .filter_map(|m| match m {
+            cargo_metadata::Message::CompilerArtifact(artifact) => Some(artifact),
+            _ => None,
+        })
+        .last()
+        .ok_or(anyhow!(
+            "Cargo failed to produce any compilation artifacts. \
+                 Please check that your project contains a NEAR smart contract."
+        ))?;
+    // The project could have generated many auxiliary files, we are only interested in .wasm files
+    let wasm_files = compile_artifact
+        .filenames
+        .iter()
+        .filter(|f| f.as_str().ends_with(".wasm"))
+        .collect::<Vec<_>>();
+    match wasm_files.as_slice() {
+        [] => Err(anyhow!(
+            "Compilation resulted in no '.wasm' target files. \
+                 Please check that your project contains a NEAR smart contract."
+        )),
+        [file] => Ok(tokio::fs::read(file.canonicalize()?).await?),
+        _ => Err(anyhow!(
+            "Compilation resulted in more than one '.wasm' target file: {:?}",
+            wasm_files
+        )),
+    }
+}
+
 /// Builds the cargo project located at `project_path` and returns the generated wasm file contents.
 ///
 /// NOTE: This macro does not check whether the resulting wasm file is a valid smart
@@ -89,38 +123,7 @@ impl<P: AsRef<Path>> __ContractCompiler<P> {
 
     pub async fn compile(self) -> anyhow::Result<Vec<u8>> {
         let contract_path = resolve_path(Path::new(self.caller), self.project_path)?;
-
-        let messages = build_cargo_project(contract_path).await?;
-        // We find the last compiler artifact message which should contain information about the
-        // resulting .wasm file
-        let compile_artifact = messages
-            .iter()
-            .filter_map(|m| match m {
-                cargo_metadata::Message::CompilerArtifact(artifact) => Some(artifact),
-                _ => None,
-            })
-            .last()
-            .ok_or(anyhow!(
-                "Cargo failed to produce any compilation artifacts. \
-                     Please check that your project contains a NEAR smart contract."
-            ))?;
-        // The project could have generated many auxiliary files, we are only interested in .wasm files
-        let wasm_files = compile_artifact
-            .filenames
-            .iter()
-            .filter(|f| f.as_str().ends_with(".wasm"))
-            .collect::<Vec<_>>();
-        match wasm_files.as_slice() {
-            [] => Err(anyhow!(
-                "Compilation resulted in no '.wasm' target files. \
-                     Please check that your project contains a NEAR smart contract."
-            )),
-            [file] => Ok(tokio::fs::read(file.canonicalize()?).await?),
-            _ => Err(anyhow!(
-                "Compilation resulted in more than one '.wasm' target file: {:?}",
-                wasm_files
-            )),
-        }
+        compile_project(&contract_path).await
     }
 }
 

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "unstable")]
 mod cargo;
 #[cfg(feature = "unstable")]
-pub use cargo::compile_project;
+pub use cargo::__ContractCompiler;
 
 mod network;
 mod rpc;

--- a/workspaces/tests/deploy_project.rs
+++ b/workspaces/tests/deploy_project.rs
@@ -6,7 +6,7 @@ use workspaces::prelude::*;
 #[test(tokio::test)]
 async fn test_dev_deploy_project() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
-    let wasm = workspaces::compile_project("./tests/test-contracts/status-message").await?;
+    let wasm = workspaces::compile_contract!("./test-contracts/status-message").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
     let _res = contract


### PR DESCRIPTION
Implements resolution for the issue pointed out in https://github.com/near/workspaces-rs/pull/77#discussion_r820755762

> TBH, this path is a bit confusing.. it's not immediately clear that it's relative to the `workspaces` folder (it reads as though this path points to `workspaces/tests/tests/test-contracts/status-message`).
> 
> Ideally, given the location of this file, shouldn't the contract path be `./test-contracts/status-message`?
> 
> I'm thinking maybe we should wrap the `compile_project` function in a macro like `compile!()` that internally checks `file!()`, getting the parent and resolving relative paths from there (leaving paths as-is if they're already absolute).
> 
> Something like this:
> 
> ```rust
> #[macro_export]
> macro_rules! compile {
>     ($contract_path:expr) => {
>         $crate::__compile_contract(::std::path::Path::new(file!()), $contract_path)
>     };
> }
> ```
> 
> Although there's an issue when using a cargo workspace with members (as with the case of `workspaces-rs`), because `file!()` returns the path relative to the root workspace and not the member crate itself. So, from `deploy_project.rs`, `parent(file!())` returns `workspaces/tests`
> 
> I'm thinking we could use `cargo-metadata` to first, return all the members, with their respective paths, we can then find the member that owns the path returned by `parent(file!())` and resolve the relative path from there.
> 
> Although, you'd have to introduce new dependencies like [`pathdiff`](https://docs.rs/pathdiff/0.2.1/pathdiff/fn.diff_paths.html) to resolve relative paths, seeing as the stdlib doesn't have that functionality.