### PR TITLE
feat: reduce retries time

### DIFF
--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -382,8 +382,9 @@ where
     F: FnMut() -> T,
     T: core::future::Future<Output = Result<R, E>>,
 {
-    // Exponential backoff starting w/ 10ms for maximum retry of 5 times:
-    let retry_strategy = ExponentialBackoff::from_millis(10).map(jitter).take(5);
+    // Exponential backoff starting w/ 5ms for maximum retry of 4 times with the following delays:
+    //   5, 25, 125, 625 ms
+    let retry_strategy = ExponentialBackoff::from_millis(5).map(jitter).take(4);
 
     Retry::spawn(retry_strategy, task).await
 }


### PR DESCRIPTION
this ones pretty simple. In the worst case of something going wrong, we shouldn't be waiting 100s to do the last retry and then throw an error at the end. To remedy this, reduce the retries time to a max of 625ms at the worst case

Should close https://github.com/near/workspaces-rs/issues/41 after this one