### PR TITLE
Chore/cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This software is in very early alpha (use at your own risk). Only local sandboxe
 [dependencies]
 workspaces = "0.1"
 ```
-Remember to grab the current revision since things are likely to change until published.
 
 ## Testing
 A simple test to get us going and familiar with the features:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,16 @@ This software is in very early alpha (use at your own risk). Only local sandboxe
 
 ## Requirements
 - rust v1.56 and up
-- MacOS (x86) or Linux (x86) for sandbox tests. Testnet is available regardless
+- MacOS (x86), M1 (thru rosetta) or Linux (x86) for sandbox tests. Testnet is available regardless
+
+### M1 MacOS Setup
+To be able to use this library on an M1 Mac, we would need to setup rosetta plus our cross compile target:
+```
+softwareupdate --install-rosetta
+rustup default stable-x86_64-apple-darwin
+```
+Then we are good to go.
+
 
 ## Include it in our project
 ```

--- a/README.md
+++ b/README.md
@@ -36,21 +36,17 @@ use workspaces::prelude::*;
 async fn test_deploy_and_view() -> anyhow::Result<()> {
     let worker = workspaces::sandbox();
 
-    let contract = worker.dev_deploy(include_bytes!("path/to/file.wasm").to_vec())
+    let contract = worker.dev_deploy(include_bytes!("path/to/file.wasm"))
         .await
         .expect("could not dev-deploy contract");
 
-    let result: String = contract.view(
-        &worker,
-        "function_name",
-        serde_json::json!({
+    let result: String = contract.call(&worker, "function_name")
+        .args_json(serde_json::json!({
             "some_arg": "some_value",
-        })
-        .to_string()
-        .into_bytes(),
-    )
-    .await?
-    .json()?;
+        }))?
+        .view()
+        .await?
+        .json()?;
 
     assert_eq!(result, "OUR_EXPECTED_RESULT");
     Ok(())
@@ -58,9 +54,9 @@ async fn test_deploy_and_view() -> anyhow::Result<()> {
 ```
 
 ## Examples
-Some examples can be found `examples/src/*.rs` to run it standalone.
+Some examples can be found in `examples/src/*.rs` to run it standalone.
 
-To run the NFT example, run:
+To run the NFT example, execute:
 ```
 cargo run --example nft
 ```
@@ -103,6 +99,6 @@ async fn call_my_func(worker: Worker<impl Network>, contract: &Contract) -> anyh
 // Create a helper function that deploys a specific contract
 // NOTE: `dev_deploy` is only available on `DevNetwork`s such sandbox and testnet.
 async fn deploy_my_contract(worker: Worker<impl DevNetwork>) -> anyhow::Result<Contract> {
-    worker.dev_deploy(std::fs::read(CONTRACT_FILE)?).await
+    worker.dev_deploy(&std::fs::read(CONTRACT_FILE)?).await
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,17 @@
-# NEAR Workspaces (Rust Edition)
-A set of functions provided to automate workflows and write tests, such as the ability to deploy and run NEAR contracts, along with several other functions to aid in development and maintenance.
+<div align="center">
 
-This software is in very early alpha (use at your own risk). Only local sandboxed environments and testnet are available currently to run this library on.
+  <h1><code>NEAR Workspaces (Rust Edition)</code></h1>
+
+  <p>
+    <strong>Rust library for automating workflows and writing tests for NEAR smart contracts. This software is in early alpha (use at your own risk)</strong>
+  </p>
+
+  <p>
+    <a href="https://crates.io/crates/workspaces"><img src="https://img.shields.io/crates/v/workspaces.svg?style=flat-square" alt="Crates.io version" /></a>
+    <a href="https://crates.io/crates/workspaces"><img src="https://img.shields.io/crates/d/workspaces.svg?style=flat-square" alt="Download" /></a>
+    <a href="https://docs.rs/workspaces"><img src="https://docs.rs/workspaces/badge.svg" alt="Reference Documentation" /></a>
+  </p>
+</div>
 
 ## Requirements
 - rust v1.56 and up
@@ -12,14 +22,6 @@ To be able to use this library on an M1 Mac, we would need to setup rosetta plus
 ```
 softwareupdate --install-rosetta
 rustup default stable-x86_64-apple-darwin
-```
-Then we are good to go.
-
-
-## Include it in our project
-```
-[dependencies]
-workspaces = "0.1"
 ```
 
 ## Testing

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -31,7 +31,7 @@ async fn create_ref(
         .transact()
         .await?;
 
-    // NOTE: We are not pulling down the contract's data here, so we'll need ot initalize
+    // NOTE: We are not pulling down the contract's data here, so we'll need to initalize
     // our own set of metadata. This is because the contract's data is too big for the rpc
     // service to pull down (i.e. greater than 50mb).
 

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -10,6 +10,6 @@ pub use network::transaction::Function;
 pub use network::{Account, AccountDetails, Block, Contract, DevNetwork, Network};
 pub use types::{AccessKey, AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
-    mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_mainnet_archival, with_sandbox,
-    with_testnet, Worker,
+    mainnet, mainnet_archival, sandbox, testnet, testnet_archival, with_mainnet,
+    with_mainnet_archival, with_sandbox, with_testnet, with_testnet_archival, Worker,
 };

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -10,5 +10,6 @@ pub use network::transaction::Function;
 pub use network::{Account, AccountDetails, Block, Contract, DevNetwork, Network};
 pub use types::{AccessKey, AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
-    mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_sandbox, with_testnet, Worker,
+    mainnet, mainnet_archival, sandbox, testnet, with_mainnet, with_mainnet_archival, with_sandbox,
+    with_testnet, Worker,
 };

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -23,6 +23,7 @@ impl Account {
         Self { id, signer }
     }
 
+    /// Grab the current account identifier
     pub fn id(&self) -> &AccountId {
         &self.id
     }
@@ -146,10 +147,14 @@ impl Contract {
         Self { account }
     }
 
+    /// Grab the current contract identifier
     pub fn id(&self) -> &AccountId {
         &self.account.id
     }
 
+    /// Casts the current [`Contract`] into an [`Account`] type. This does
+    /// nothing on chain/network, and is merely allowing `Account::*` functions
+    /// to be used from this `Contract`.
     pub fn as_account(&self) -> &Account {
         &self.account
     }

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -18,6 +18,7 @@ use crate::{Contract, CryptoHash};
 
 const RPC_URL: &str = "https://rpc.testnet.near.org";
 const HELPER_URL: &str = "https://helper.testnet.near.org";
+const ARCHIVAL_URL: &str = "https://archival-rpc.testnet.near.org";
 
 pub struct Testnet {
     client: Client,
@@ -33,6 +34,18 @@ impl Testnet {
                 root_id: AccountId::from_str("testnet").unwrap(),
                 keystore_path: PathBuf::from(".near-credentials/testnet/"),
                 rpc_url: RPC_URL.into(),
+            },
+        }
+    }
+
+    pub(crate) fn archival() -> Self {
+        Self {
+            client: Client::new(ARCHIVAL_URL.into()),
+            info: Info {
+                name: "testnet-archival".into(),
+                root_id: AccountId::from_str("testnet").unwrap(),
+                keystore_path: PathBuf::from(".near-credentials/testnet/"),
+                rpc_url: ARCHIVAL_URL.into(),
             },
         }
     }

--- a/workspaces/src/network/transaction.rs
+++ b/workspaces/src/network/transaction.rs
@@ -28,6 +28,8 @@ pub struct Function<'a> {
 }
 
 impl<'a> Function<'a> {
+    /// Initialize a new instance of [`Function`], tied to a specific function on a
+    /// contract that lives directly on a contract we've specified in [`Transaction`].
     pub fn new(name: &'a str) -> Self {
         Self {
             name,
@@ -37,26 +39,37 @@ impl<'a> Function<'a> {
         }
     }
 
+    /// Provide the arguments for the call. These args are serialized bytes from either
+    /// a JSON or Borsh serializable set of arguments. To use the more specific versions
+    /// with better quality of life, use `args_json` or `args_borsh`.
     pub fn args(mut self, args: Vec<u8>) -> Self {
         self.args = args;
         self
     }
 
+    /// Similiar to `args`, specify an argument that is JSON serializable and can be
+    /// accepted by the equivalent contract. Recommend to use something like
+    /// `serde_json::json!` macro to easily serialize the arguments.
     pub fn args_json<U: serde::Serialize>(mut self, args: U) -> anyhow::Result<Self> {
         self.args = serde_json::to_vec(&args)?;
         Ok(self)
     }
 
+    /// Similiar to `args`, specify an argument that is borsh serializable and can be
+    /// accepted by the equivalent contract.
     pub fn args_borsh<U: borsh::BorshSerialize>(mut self, args: U) -> anyhow::Result<Self> {
         self.args = args.try_to_vec()?;
         Ok(self)
     }
 
+    /// Specify the amount of tokens to be deposited where `deposit` is the amount of
+    /// tokens in yocto near.
     pub fn deposit(mut self, deposit: Balance) -> Self {
         self.deposit = deposit;
         self
     }
 
+    /// Specify the amount of gas to be used where `gas` is the amount of gas in yocto near.
     pub fn gas(mut self, gas: Gas) -> Self {
         self.gas = gas;
         self

--- a/workspaces/src/network/transaction.rs
+++ b/workspaces/src/network/transaction.rs
@@ -15,6 +15,8 @@ use crate::types::{AccessKey, AccountId, Balance, Gas, InMemorySigner, PublicKey
 use crate::worker::Worker;
 use crate::Account;
 
+const MAX_GAS: Gas = 300_000_000_000_000;
+
 /// A set of arguments we can provide to a transaction, containing
 /// the function name, arguments, the amount of gas to use and deposit.
 #[derive(Debug, Clone)]
@@ -58,6 +60,11 @@ impl<'a> Function<'a> {
     pub fn gas(mut self, gas: Gas) -> Self {
         self.gas = gas;
         self
+    }
+
+    /// Use the maximum amount of gas possible to perform this function call into the contract.
+    pub fn max_gas(self) -> Self {
+        self.gas(MAX_GAS)
     }
 }
 
@@ -232,6 +239,11 @@ impl<'a, 'b, T: Network> CallTransaction<'a, 'b, T> {
     pub fn gas(mut self, gas: u64) -> Self {
         self.function = self.function.gas(gas);
         self
+    }
+
+    /// Use the maximum amount of gas possible to perform this transaction.
+    pub fn max_gas(self) -> Self {
+        self.gas(MAX_GAS)
     }
 
     /// Finally, send the transaction to the network. This will consume the `CallTransaction`

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -58,3 +58,11 @@ where
 {
     task(mainnet()).await
 }
+
+pub async fn with_mainnet_archival<F, T>(task: F) -> T::Output
+where
+    F: Fn(Worker<Mainnet>) -> T,
+    T: core::future::Future,
+{
+    task(mainnet_archival()).await
+}

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -19,26 +19,36 @@ where
     }
 }
 
+/// Spin up a new sandbox instance, and grab a [`Worker`] that interacts with it.
 pub fn sandbox() -> Worker<Sandbox> {
     Worker::new(Sandbox::new())
 }
 
+/// Connect to the [testnet](https://explorer.testnet.near.org/) network, and grab
+/// a [`Worker`] that can interact with it.
 pub fn testnet() -> Worker<Testnet> {
     Worker::new(Testnet::new())
 }
 
+/// Connect to the [testnet archival](https://near-nodes.io/intro/node-types#archival-node)
+/// network, and grab a [`Worker`] that can interact with it.
 pub fn testnet_archival() -> Worker<Testnet> {
     Worker::new(Testnet::archival())
 }
 
+/// Connect to the [mainnet](https://explorer.near.org/) network, and grab
+/// a [`Worker`] that can interact with it.
 pub fn mainnet() -> Worker<Mainnet> {
     Worker::new(Mainnet::new())
 }
 
+/// Connect to the [mainnet archival](https://near-nodes.io/intro/node-types#archival-node)
+/// network, and grab a [`Worker`] that can interact with it.
 pub fn mainnet_archival() -> Worker<Mainnet> {
     Worker::new(Mainnet::archival())
 }
 
+/// Run a locally scoped task with a [`sandbox`] instanced [`Worker`] is supplied.
 pub async fn with_sandbox<F, T>(task: F) -> T::Output
 where
     F: Fn(Worker<Sandbox>) -> T,
@@ -47,6 +57,7 @@ where
     task(sandbox()).await
 }
 
+/// Run a locally scoped task with a [`testnet`] instanced [`Worker`] is supplied.
 pub async fn with_testnet<F, T>(task: F) -> T::Output
 where
     F: Fn(Worker<Testnet>) -> T,
@@ -55,6 +66,7 @@ where
     task(testnet()).await
 }
 
+/// Run a locally scoped task with a [`testnet_archival`] instanced [`Worker`] is supplied.
 pub async fn with_testnet_archival<F, T>(task: F) -> T::Output
 where
     F: Fn(Worker<Testnet>) -> T,
@@ -63,6 +75,7 @@ where
     task(testnet_archival()).await
 }
 
+/// Run a locally scoped task with a [`mainnet`] instanced [`Worker`] is supplied.
 pub async fn with_mainnet<F, T>(task: F) -> T::Output
 where
     F: Fn(Worker<Mainnet>) -> T,
@@ -71,6 +84,7 @@ where
     task(mainnet()).await
 }
 
+/// Run a locally scoped task with a [`mainnet_archival`] instanced [`Worker`] is supplied.
 pub async fn with_mainnet_archival<F, T>(task: F) -> T::Output
 where
     F: Fn(Worker<Mainnet>) -> T,

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -27,6 +27,10 @@ pub fn testnet() -> Worker<Testnet> {
     Worker::new(Testnet::new())
 }
 
+pub fn testnet_archival() -> Worker<Testnet> {
+    Worker::new(Testnet::archival())
+}
+
 pub fn mainnet() -> Worker<Mainnet> {
     Worker::new(Mainnet::new())
 }
@@ -49,6 +53,14 @@ where
     T: core::future::Future,
 {
     task(testnet()).await
+}
+
+pub async fn with_testnet_archival<F, T>(task: F) -> T::Output
+where
+    F: Fn(Worker<Testnet>) -> T,
+    T: core::future::Future,
+{
+    task(testnet_archival()).await
 }
 
 pub async fn with_mainnet<F, T>(task: F) -> T::Output


### PR DESCRIPTION
Some cleanup before release 0.2:
- Added `testnet_archival` and `with_{mainnet, testnet}_archival` functions
- fixup readme, added M1 setup and added badges
- updated and added more docs to functions
- Added `max_gas` convenience function so we don't have to do `.gas(300_ ...)` anymore