### PR TITLE
feat: Moved credentials storage to user side

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-  <h1><code>NEAR Workspaces (Rust Edition)</code></h1>
+  <h1>NEAR Workspaces (Rust Edition)</h1>
 
   <p>
     <strong>Rust library for automating workflows and writing tests for NEAR smart contracts. This software is in early alpha (use at your own risk)</strong>

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use near_primitives::views::AccountView;
 
 use crate::types::{AccountId, Balance, InMemorySigner};
@@ -127,6 +129,19 @@ impl Account {
         contract_id: &AccountId,
     ) -> Transaction<'a> {
         Transaction::new(worker.client(), self.signer().clone(), contract_id.clone())
+    }
+
+    /// Store the credentials of this account locally in the directory provided.
+    pub fn store_credentials(&self, save_dir: impl AsRef<Path>) -> anyhow::Result<()> {
+        let savepath = save_dir.as_ref().to_path_buf();
+        std::fs::create_dir_all(save_dir)?;
+
+        let mut savepath = savepath.join(self.id.to_string());
+        savepath.set_extension("json");
+
+        crate::rpc::tool::write_cred_to_file(&savepath, &self.id, &self.signer.0.secret_key);
+
+        Ok(())
     }
 }
 

--- a/workspaces/src/network/account.rs
+++ b/workspaces/src/network/account.rs
@@ -132,7 +132,7 @@ impl Account {
     }
 
     /// Store the credentials of this account locally in the directory provided.
-    pub fn store_credentials(&self, save_dir: impl AsRef<Path>) -> anyhow::Result<()> {
+    pub async fn store_credentials(&self, save_dir: impl AsRef<Path>) -> anyhow::Result<()> {
         let savepath = save_dir.as_ref().to_path_buf();
         std::fs::create_dir_all(save_dir)?;
 

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -72,16 +72,6 @@ where
     async fn dev_generate(&self) -> (AccountId, SecretKey) {
         let id = crate::rpc::tool::random_account_id();
         let sk = SecretKey::from_seed(KeyType::ED25519, DEV_ACCOUNT_SEED);
-
-        let mut savepath = self.info().keystore_path.clone();
-
-        // TODO: potentially make this into the async version:
-        std::fs::create_dir_all(savepath.clone()).unwrap();
-
-        savepath = savepath.join(id.to_string());
-        savepath.set_extension("json");
-        crate::rpc::tool::write_cred_to_file(&savepath, id.clone(), sk.clone());
-
         (id, sk)
     }
 

--- a/workspaces/src/rpc/tool.rs
+++ b/workspaces/src/rpc/tool.rs
@@ -8,9 +8,10 @@ use chrono::Utc;
 use rand::Rng;
 use url::Url;
 
+use near_crypto::SecretKey;
 use near_primitives::views::StateItem;
 
-use crate::types::{AccountId, PublicKey, SecretKey};
+use crate::types::{AccountId, PublicKey};
 
 /// Convert `StateItem`s over to a Map<data_key, value_bytes> representation.
 /// Assumes key and value are base64 encoded, so this also decodes them.
@@ -54,7 +55,7 @@ pub(crate) async fn url_create_account(
     Ok(())
 }
 
-pub(crate) fn write_cred_to_file(path: &Path, id: AccountId, sk: SecretKey) {
+pub(crate) fn write_cred_to_file(path: &Path, id: &AccountId, sk: &SecretKey) {
     let mut file = File::create(path).expect("Failed to create / write a key file.");
 
     #[cfg(unix)]


### PR DESCRIPTION
Now no longer polluting working directory with credentials constantly being saved. And now allowing users to store it themselves if they wish to save them.

Also fixed a minor thing with the README title having code formatting.