### PR TITLE
fix: move TLA creator trait to dev network

### DIFF
--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -1,12 +1,7 @@
-use std::path::PathBuf;
-
-use async_trait::async_trait;
-
 use crate::network::Info;
-use crate::network::{Account, CallExecution, NetworkClient, NetworkInfo, TopLevelAccountCreator};
+use crate::network::{NetworkClient, NetworkInfo};
 use crate::rpc::client::Client;
-use crate::types::{AccountId, SecretKey};
-use crate::Contract;
+use std::path::PathBuf;
 
 const RPC_URL: &str = "https://rpc.mainnet.near.org";
 const ARCHIVAL_URL: &str = "https://archival-rpc.mainnet.near.org";
@@ -39,26 +34,6 @@ impl Mainnet {
                 rpc_url: ARCHIVAL_URL.into(),
             },
         }
-    }
-}
-
-#[async_trait]
-impl TopLevelAccountCreator for Mainnet {
-    async fn create_tla(
-        &self,
-        _id: AccountId,
-        _sk: SecretKey,
-    ) -> anyhow::Result<CallExecution<Account>> {
-        panic!("Unsupported for now: https://github.com/near/workspaces-rs/issues/18");
-    }
-
-    async fn create_tla_and_deploy(
-        &self,
-        _id: AccountId,
-        _sk: SecretKey,
-        _wasm: &[u8],
-    ) -> anyhow::Result<CallExecution<Contract>> {
-        panic!("Unsupported for now: https://github.com/near/workspaces-rs/issues/18");
     }
 }
 

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -143,12 +143,12 @@ where
     }
 }
 
-pub trait Network: TopLevelAccountCreator + NetworkInfo + NetworkClient + Send + Sync {}
+pub trait Network: NetworkInfo + NetworkClient + Send + Sync {}
 
-impl<T> Network for T where T: TopLevelAccountCreator + NetworkInfo + NetworkClient + Send + Sync {}
+impl<T> Network for T where T: NetworkInfo + NetworkClient + Send + Sync {}
 
 /// DevNetwork is a Network that can call into `dev_create` and `dev_deploy` to create developer accounts.
-pub trait DevNetwork: AllowDevAccountCreation + Network {}
+pub trait DevNetwork: AllowDevAccountCreation + Network + TopLevelAccountCreator {}
 
 // Implemented by default if we have `AllowDevAccountCreation`
-impl<T> DevNetwork for T where T: AllowDevAccountCreation + Network {}
+impl<T> DevNetwork for T where T: AllowDevAccountCreation + Network + TopLevelAccountCreator {}


### PR DESCRIPTION
Having this fail at runtime is probably not ideal.