### PR TITLE
fix: avoid creating new client for every request

### DIFF
--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -13,7 +13,7 @@ pub struct Mainnet {
 impl Mainnet {
     pub(crate) fn new() -> Self {
         Self {
-            client: Client::new(RPC_URL.into()),
+            client: Client::new(RPC_URL),
             info: Info {
                 name: "mainnet".into(),
                 root_id: "near".parse().unwrap(),
@@ -25,7 +25,7 @@ impl Mainnet {
 
     pub(crate) fn archival() -> Self {
         Self {
-            client: Client::new(ARCHIVAL_URL.into()),
+            client: Client::new(ARCHIVAL_URL),
             info: Info {
                 name: "mainnet-archival".into(),
                 root_id: "near".parse().unwrap(),

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -44,7 +44,7 @@ impl Sandbox {
         let mut server = SandboxServer::default();
         server.start().unwrap();
 
-        let client = Client::new(server.rpc_addr());
+        let client = Client::new(&server.rpc_addr());
         let info = Info {
             name: "sandbox".to_string(),
             root_id: AccountId::from_str("test.near").unwrap(),

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -25,7 +25,7 @@ pub struct Testnet {
 impl Testnet {
     pub(crate) fn new() -> Self {
         Self {
-            client: Client::new(RPC_URL.into()),
+            client: Client::new(RPC_URL),
             info: Info {
                 name: "testnet".into(),
                 root_id: AccountId::from_str("testnet").unwrap(),
@@ -37,7 +37,7 @@ impl Testnet {
 
     pub(crate) fn archival() -> Self {
         Self {
-            client: Client::new(ARCHIVAL_URL.into()),
+            client: Client::new(ARCHIVAL_URL),
             info: Info {
                 name: "testnet-archival".into(),
                 root_id: AccountId::from_str("testnet").unwrap(),

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -28,15 +28,17 @@ pub(crate) const DEFAULT_CALL_DEPOSIT: Balance = 0;
 const ERR_INVALID_VARIANT: &str =
     "Incorrect variant retrieved while querying: maybe a bug in RPC code?";
 
-/// A client that wraps around JsonRpcClient, and provides more capabilities such
+/// A client that wraps around [`JsonRpcClient`], and provides more capabilities such
 /// as retry w/ exponential backoff and utility functions for sending transactions.
 pub struct Client {
-    rpc_addr: String,
+    rpc_client: JsonRpcClient,
 }
 
 impl Client {
-    pub(crate) fn new(rpc_addr: String) -> Self {
-        Self { rpc_addr }
+    pub(crate) fn new(rpc_addr: &str) -> Self {
+        Self {
+            rpc_client: JsonRpcClient::connect(rpc_addr),
+        }
     }
 
     pub(crate) async fn query_broadcast_tx(
@@ -47,7 +49,7 @@ impl Client {
         near_jsonrpc_primitives::types::transactions::RpcTransactionError,
     > {
         retry(|| async {
-            let result = JsonRpcClient::connect(&self.rpc_addr).call(method).await;
+            let result = self.rpc_client.call(method).await;
             match &result {
                 Ok(response) => {
                     // When user sets logging level to INFO we only print one-liners with submitted
@@ -87,7 +89,7 @@ impl Client {
     where
         M: methods::RpcMethod,
     {
-        retry(|| async { JsonRpcClient::connect(&self.rpc_addr).call(method).await }).await
+        retry(|| async { self.rpc_client.call(method).await }).await
     }
 
     pub(crate) async fn query<M>(&self, method: &M) -> MethodCallResult<M::Response, M::Error>
@@ -97,7 +99,7 @@ impl Client {
         M::Error: Debug,
     {
         retry(|| async {
-            let result = JsonRpcClient::connect(&self.rpc_addr).call(method).await;
+            let result = self.rpc_client.call(method).await;
             tracing::debug!(
                 target: "workspaces",
                 "Querying RPC with {:?} resulted in {:?}",


### PR DESCRIPTION
Not sure if there is some context I'm missing for why this isn't kept, but this seems to avoid a lot of unnecessary initialization/allocations