### PR TITLE
fix!: Key type of state map and remove exposed primitives type

### DIFF
--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -81,7 +81,7 @@ async fn main() -> anyhow::Result<()> {
 
         let mut state_items = worker.view_state(&contract_id, None).await?;
 
-        let state = state_items.remove("STATE").unwrap();
+        let state = state_items.remove(b"STATE".as_slice()).unwrap();
         let status_msg = StatusMessage::try_from_slice(&state)?;
 
         (contract_id, status_msg)

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -167,19 +167,15 @@ impl Client {
     pub(crate) async fn view_state(
         &self,
         contract_id: AccountId,
-        prefix: Option<StoreKey>,
-    ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
-        self.view_state_raw(contract_id, prefix, None)
-            .await?
-            .into_iter()
-            .map(|(k, v)| Ok((String::from_utf8(k)?, v.to_vec())))
-            .collect()
+        prefix: Option<&[u8]>,
+    ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
+        self.view_state_raw(contract_id, prefix, None).await
     }
 
     pub(crate) async fn view_state_raw(
         &self,
         contract_id: AccountId,
-        prefix: Option<StoreKey>,
+        prefix: Option<&[u8]>,
         block_id: Option<BlockId>,
     ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
         let block_reference = block_id
@@ -191,7 +187,7 @@ impl Client {
                 block_reference,
                 request: QueryRequest::ViewState {
                     account_id: contract_id,
-                    prefix: prefix.clone().unwrap_or_else(|| vec![].into()),
+                    prefix: StoreKey::from(prefix.map(Vec::from).unwrap_or_default()),
                 },
             })
             .await?;

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -171,14 +171,6 @@ impl Client {
         &self,
         contract_id: AccountId,
         prefix: Option<&[u8]>,
-    ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
-        self.view_state_raw(contract_id, prefix, None).await
-    }
-
-    pub(crate) async fn view_state_raw(
-        &self,
-        contract_id: AccountId,
-        prefix: Option<&[u8]>,
         block_id: Option<BlockId>,
     ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
         let block_reference = block_id

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -101,7 +101,7 @@ impl<'a, 'b> ImportContractTransaction<'a, 'b> {
         if self.import_data {
             records.extend(
                 self.from_network
-                    .view_state_raw(account_id.clone(), None, self.block_id)
+                    .view_state(account_id.clone(), None, self.block_id)
                     .await?
                     .into_iter()
                     .map(|(key, value)| StateRecord::Data {

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use near_primitives::views::AccountView;
@@ -207,6 +208,15 @@ impl Contract {
     /// View the WASM code bytes of this contract.
     pub async fn view_code<T: Network>(&self, worker: &Worker<T>) -> anyhow::Result<Vec<u8>> {
         worker.view_code(self.id()).await
+    }
+
+    /// View a contract's state map of key value pairs.
+    pub async fn view_state<T: Network>(
+        &self,
+        worker: &Worker<T>,
+        prefix: Option<&[u8]>,
+    ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
+        worker.view_state(self.id(), prefix).await
     }
 
     /// Views the current contract's details such as balance and storage usage.

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -8,7 +8,7 @@ use crate::worker::Worker;
 use crate::{Account, Block, Contract};
 use crate::{AccountDetails, Network};
 use async_trait::async_trait;
-use near_primitives::types::{Balance, StoreKey};
+use near_primitives::types::Balance;
 use std::collections::HashMap;
 
 impl<T> Clone for Worker<T> {
@@ -107,8 +107,8 @@ where
     pub async fn view_state(
         &self,
         contract_id: &AccountId,
-        prefix: Option<StoreKey>,
-    ) -> anyhow::Result<HashMap<String, Vec<u8>>> {
+        prefix: Option<&[u8]>,
+    ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
         self.client().view_state(contract_id.clone(), prefix).await
     }
 

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -109,7 +109,9 @@ where
         contract_id: &AccountId,
         prefix: Option<&[u8]>,
     ) -> anyhow::Result<HashMap<Vec<u8>, Vec<u8>>> {
-        self.client().view_state(contract_id.clone(), prefix).await
+        self.client()
+            .view_state(contract_id.clone(), prefix, None)
+            .await
     }
 
     /// View the latest block from the network

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -34,9 +34,9 @@ async fn view_status_state(
         .transact()
         .await?;
 
-    let mut state_items = worker.view_state(contract.id(), None).await?;
+    let mut state_items = contract.view_state(&worker, None).await?;
     let state = state_items
-        .remove("STATE")
+        .remove(b"STATE".as_slice())
         .ok_or_else(|| anyhow::anyhow!("Could not retrieve STATE"))?;
     let status_msg: StatusMessage = StatusMessage::try_from_slice(&state)?;
 


### PR DESCRIPTION
- Removes `StoreKey` from public interface for using prefixes
- Changes state map to have keys as bytes (there is nothing enforcing these to be utf8, this is incorrect)
- Adds helper function to contract struct to retrieve state