### PR TITLE
hotfix: doc builds on docs.rs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,8 @@ softwareupdate --install-rosetta
 rustup default stable-x86_64-apple-darwin
 ```
 
-### Note about compiling with NEAR Contracts
-`workspaces-rs`, the library itself, does not currently compile to WASM. So, if we were compiling it alongside a `wasm32` target, such as compiling alongside a NEAR contract:
-```toml
-# Cargo.toml
-[dependencies]
-workspaces = "*"
-near-sdk = "*"
-```
-It would throw an error when we run `cargo build --target wasm32-unknown-unknown`. Instead, we should add `workspaces-rs` into `[dev-dependencies]` for testing contracts:
-```toml
-# Cargo.toml
-[dependencies]
-near-sdk = "*"
-
-[dev-dependencies]
-workspaces = "*"
-```
+### WASM compilation not supported
+`workspaces-rs`, the library itself, does not currently compile to WASM. Best to put this dependency in `[dev-dependencies]` section of `Cargo.toml` if we were trying to run this library alongside something that already does compile to WASM, such as `near-sdk-rs`.
 
 ## Simple Testing Case
 A simple test to get us going and familiar with `workspaces` framework. Here, we will be going through the NFT contract and how we can test it with `workspaces-rs`.

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,5 +1,6 @@
 fn main() {
-    if !cfg!(doc) && cfg!(feature = "install") {
+    let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
+    if !doc_build && cfg!(feature = "install") {
         near_sandbox_utils::install().expect("Could not install sandbox");
     }
 }

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -1,3 +1,8 @@
+//! # NEAR Workspaces
+//!
+//! A library for automating workflows and writing tests for NEAR smart contracts.
+//! This software is not final, and will likely change.
+
 #[cfg(feature = "unstable")]
 mod cargo;
 #[cfg(feature = "unstable")]

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -5,6 +5,16 @@ use std::path::PathBuf;
 const RPC_URL: &str = "https://rpc.mainnet.near.org";
 const ARCHIVAL_URL: &str = "https://archival-rpc.mainnet.near.org";
 
+/// Mainnet related configuration for interacting with mainnet. Look at
+/// [`workspaces::mainnet`] and [`workspaces::mainnet_archival`] for how to
+/// spin up a [`Worker`] that can be used to interact with mainnet. Note that
+/// mainnet account creation is not currently supported, and these calls into
+/// creating a mainnet worker is meant for retrieving data and/or making
+/// queries only.
+///
+/// [`workspaces::mainnet`]: crate::mainnet
+/// [`workspaces::mainnet_archival`]: crate::mainnet_archival
+/// [`Worker`]: crate::Worker
 pub struct Mainnet {
     client: Client,
     info: Info,

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -20,6 +20,11 @@ pub(crate) const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 
 const DEFAULT_DEPOSIT: Balance = 100 * NEAR_BASE;
 
+/// Local sandboxed environment/network, which can be used to test without interacting with
+/// networks that are online such as mainnet and testnet. Look at [`workspaces::sandbox`]
+/// for how to spin up a sandboxed network and interact with it.
+///
+/// [`workspaces::sandbox`]: crate::sandbox
 pub struct Sandbox {
     server: SandboxServer,
     client: Client,

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -17,6 +17,13 @@ const RPC_URL: &str = "https://rpc.testnet.near.org";
 const HELPER_URL: &str = "https://helper.testnet.near.org";
 const ARCHIVAL_URL: &str = "https://archival-rpc.testnet.near.org";
 
+/// Testnet related configuration for interacting with testnet. Look at
+/// [`workspaces::testnet`] and [`workspaces::testnet_archival`] for how
+/// to spin up a [`Worker`] that can be used to run tests in testnet.
+///
+/// [`workspaces::testnet`]: crate::testnet
+/// [`workspaces::testnet_archival`]: crate::testnet_archival
+/// [`Worker`]: crate::Worker
 pub struct Testnet {
     client: Client,
     info: Info,

--- a/workspaces/src/network/variants.rs
+++ b/workspaces/src/network/variants.rs
@@ -66,6 +66,8 @@ where
     }
 }
 
+/// Network trait specifies the functionality of a network type such as mainnet, testnet or any
+/// other networks that are not specified in this library.
 pub trait Network: NetworkInfo + NetworkClient + Send + Sync {}
 
 impl<T> Network for T where T: NetworkInfo + NetworkClient + Send + Sync {}

--- a/workspaces/src/prelude.rs
+++ b/workspaces/src/prelude.rs
@@ -1,1 +1,3 @@
+//! All traits that are essential to the ease of use of workspaces.
+
 pub use crate::network::{DevAccountDeployer, TopLevelAccountCreator};

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -8,6 +8,11 @@ use crate::rpc::client::Client;
 use crate::types::{BlockHeight, SecretKey};
 use crate::{AccountId, Contract, CryptoHash, InMemorySigner};
 
+/// A [`Transaction`]-like object that allows us to specify details about importing
+/// a contract from a different network into our sandbox local network. This creates
+/// a new [`Transaction`] to be committed to the sandbox network once `transact()`
+/// has been called. This does not commit any new transactions from the network
+/// this object is importing from.
 pub struct ImportContractTransaction<'a, 'b> {
     account_id: AccountId,
     from_network: &'a Client,
@@ -39,11 +44,19 @@ impl<'a, 'b> ImportContractTransaction<'a, 'b> {
         }
     }
 
+    /// Specify at which block height to import the contract from. This is usable with
+    /// any network this object is importing from, but be aware that only archival
+    /// networks will have the full history while networks like mainnet or testnet
+    /// only has the history from 5 or less epochs ago.
     pub fn block_height(mut self, block_height: BlockHeight) -> Self {
         self.block_id = Some(BlockId::Height(block_height));
         self
     }
 
+    /// Specify at which block hash to import the contract from. This is usable with
+    /// any network this object is importing from, but be aware that only archival
+    /// networks will have the full history while networks like mainnet or testnet
+    /// only has the history from 5 or less epochs ago.
     pub fn block_hash(mut self, block_hash: CryptoHash) -> Self {
         self.block_id = Some(BlockId::Hash(near_primitives::hash::CryptoHash(
             block_hash.0,
@@ -51,16 +64,24 @@ impl<'a, 'b> ImportContractTransaction<'a, 'b> {
         self
     }
 
+    /// Along with importing the contract code, this will import the state from the
+    /// contract itself. This is useful for testing current network state or state
+    /// at a specific block. Note that there is a limit of 50mb of state data that
+    /// can be pulled down using the usual RPC service. To get beyond this, our own
+    /// RPC node has to be spun up and used instead.
     pub fn with_data(mut self) -> Self {
         self.import_data = true;
         self
     }
 
+    /// Specifies the balance of the contract. This will override the balance currently
+    /// on the network this transaction is importing from.
     pub fn initial_balance(mut self, initial_balance: Balance) -> Self {
         self.initial_balance = Some(initial_balance);
         self
     }
 
+    /// Process the trannsaction, and return the result of the execution.
     pub async fn transact(self) -> anyhow::Result<Contract> {
         let account_id = self.account_id;
         let sk = SecretKey::from_seed(KeyType::ED25519, DEV_ACCOUNT_SEED);

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -9,6 +9,9 @@ use crate::{CryptoHash, Network, Worker};
 use crate::operations::{CallTransaction, CreateAccountTransaction, Transaction};
 use crate::result::{CallExecution, CallExecutionDetails, ViewResultDetails};
 
+/// `Account` is directly associated to an account in the network provided by the
+/// [`Worker`] that creates it. This type offers methods to interact with any
+/// network, such as creating transactions and calling into contract functions.
 pub struct Account {
     pub(crate) id: AccountId,
     pub(crate) signer: InMemorySigner,
@@ -148,6 +151,9 @@ impl Account {
 
 // TODO: allow users to create Contracts so that they can call into
 // them without deploying the contract themselves.
+/// `Contract` is directly associated to a contract in the network provided by the
+/// [`Worker`] that creates it. This type offers methods to interact with any
+/// network, such as creating transactions and calling into contract functions.
 pub struct Contract {
     pub(crate) account: Account,
 }

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -5,6 +5,10 @@ use std::sync::Arc;
 use crate::network::{Mainnet, Sandbox, Testnet};
 use crate::Network;
 
+/// The `Worker` type allows us to interact with any NEAR related networks, such
+/// as mainnet and testnet. This controls where the environment the worker is
+/// running on top of is. Refer to this for all network related actions such as
+/// deploying a contract, or interacting with transactions.
 pub struct Worker<T> {
     workspace: Arc<T>,
 }
@@ -49,7 +53,7 @@ pub async fn mainnet_archival() -> anyhow::Result<Worker<Mainnet>> {
     Ok(Worker::new(Mainnet::archival().await?))
 }
 
-/// Run a locally scoped task with a [`sandbox`] instanced [`Worker`] is supplied.
+/// Run a locally scoped task where a [`sandbox`] instanced [`Worker`] is supplied.
 pub async fn with_sandbox<F, T>(task: F) -> anyhow::Result<T::Output>
 where
     F: Fn(Worker<Sandbox>) -> T,
@@ -58,7 +62,7 @@ where
     Ok(task(sandbox().await?).await)
 }
 
-/// Run a locally scoped task with a [`testnet`] instanced [`Worker`] is supplied.
+/// Run a locally scoped task where a [`testnet`] instanced [`Worker`] is supplied.
 pub async fn with_testnet<F, T>(task: F) -> anyhow::Result<T::Output>
 where
     F: Fn(Worker<Testnet>) -> T,
@@ -67,7 +71,7 @@ where
     Ok(task(testnet().await?).await)
 }
 
-/// Run a locally scoped task with a [`testnet_archival`] instanced [`Worker`] is supplied.
+/// Run a locally scoped task where a [`testnet_archival`] instanced [`Worker`] is supplied.
 pub async fn with_testnet_archival<F, T>(task: F) -> anyhow::Result<T::Output>
 where
     F: Fn(Worker<Testnet>) -> T,
@@ -76,7 +80,7 @@ where
     Ok(task(testnet_archival().await?).await)
 }
 
-/// Run a locally scoped task with a [`mainnet`] instanced [`Worker`] is supplied.
+/// Run a locally scoped task where a [`mainnet`] instanced [`Worker`] is supplied.
 pub async fn with_mainnet<F, T>(task: F) -> anyhow::Result<T::Output>
 where
     F: Fn(Worker<Mainnet>) -> T,
@@ -85,7 +89,7 @@ where
     Ok(task(mainnet().await?).await)
 }
 
-/// Run a locally scoped task with a [`mainnet_archival`] instanced [`Worker`] is supplied.
+/// Run a locally scoped task where a [`mainnet_archival`] instanced [`Worker`] is supplied.
 pub async fn with_mainnet_archival<F, T>(task: F) -> anyhow::Result<T::Output>
 where
     F: Fn(Worker<Mainnet>) -> T,


### PR DESCRIPTION
Been trying for over a day to get `docs.rs` builds to run locally, but keep running into issues with trying to reproduce their builds like unable to find dependencies in the docker container. So felt like it's better just to not waste anymore time trying to configure that and make a release to see if actually passes this time. `DOCS_RS` looks to be the way according to multiple sources so let's go with that. It doesn't affect users who are using the library anyways, but better to get this in sooner than later so people can view the docs.

Also, added some more docs that were missing from the module level