### PR TITLE
feat: allow Worker<Betanet> creation

### DIFF
--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -22,6 +22,6 @@ pub use types::account::{Account, AccountDetails, Contract};
 pub use types::block::Block;
 pub use types::{AccessKey, AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
-    betanet, mainnet, mainnet_archival, sandbox, testnet, testnet_archival, with_mainnet,
-    with_mainnet_archival, with_sandbox, with_testnet, with_testnet_archival, Worker,
+    betanet, mainnet, mainnet_archival, sandbox, testnet, testnet_archival, with_betanet,
+    with_mainnet, with_mainnet_archival, with_sandbox, with_testnet, with_testnet_archival, Worker,
 };

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -17,6 +17,6 @@ pub use types::account::{Account, AccountDetails, Contract};
 pub use types::block::Block;
 pub use types::{AccessKey, AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
-    mainnet, mainnet_archival, sandbox, testnet, testnet_archival, with_mainnet,
+    betanet, mainnet, mainnet_archival, sandbox, testnet, testnet_archival, with_mainnet,
     with_mainnet_archival, with_sandbox, with_testnet, with_testnet_archival, Worker,
 };

--- a/workspaces/src/network/betanet.rs
+++ b/workspaces/src/network/betanet.rs
@@ -1,0 +1,51 @@
+use crate::network::{Info, NetworkClient, NetworkInfo};
+use crate::rpc::client::Client;
+use std::path::PathBuf;
+
+const RPC_URL: &str = "https://rpc.betanet.near.org";
+const ARCHIVAL_URL: &str = "https://archival-rpc.betanet.near.org";
+
+/// Betanet related configuration for interacting with betanet. Look at
+/// [`workspaces::betanet`] for how to spin up a [`Worker`] that can be
+/// used to interact with betanet. Note that betanet account creation
+/// is not currently supported, and these calls into creating a betanet
+/// worker is meant for retrieving data and/or making queries only.
+/// Also, note that betanet can be unstable and does not provide an
+/// archival endpoint similiar to that of mainnet.
+///
+/// [`workspaces::betanet`]: crate::betanet
+/// [`workspaces::betanet_archival`]: crate::betanet_archival
+/// [`Worker`]: crate::Worker
+pub struct Betanet {
+    client: Client,
+    info: Info,
+}
+
+impl Betanet {
+    pub(crate) async fn new() -> anyhow::Result<Self> {
+        let client = Client::new(RPC_URL.into());
+        client.wait_for_rpc().await?;
+
+        Ok(Self {
+            client,
+            info: Info {
+                name: "betanet".into(),
+                root_id: "near".parse().unwrap(),
+                keystore_path: PathBuf::from(".near-credentials/betanet/"),
+                rpc_url: RPC_URL.into(),
+            },
+        })
+    }
+}
+
+impl NetworkClient for Betanet {
+    fn client(&self) -> &Client {
+        &self.client
+    }
+}
+
+impl NetworkInfo for Betanet {
+    fn info(&self) -> &Info {
+        &self.info
+    }
+}

--- a/workspaces/src/network/betanet.rs
+++ b/workspaces/src/network/betanet.rs
@@ -3,7 +3,6 @@ use crate::rpc::client::Client;
 use std::path::PathBuf;
 
 const RPC_URL: &str = "https://rpc.betanet.near.org";
-const ARCHIVAL_URL: &str = "https://archival-rpc.betanet.near.org";
 
 /// Betanet related configuration for interacting with betanet. Look at
 /// [`workspaces::betanet`] for how to spin up a [`Worker`] that can be

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Currently the builtin network types are [`Mainnet`], [`Testnet`], and [`Sandbox`].
 
+mod betanet;
 mod info;
 mod mainnet;
 mod sandbox;
@@ -11,6 +12,7 @@ pub(crate) mod variants;
 
 pub(crate) use variants::DEV_ACCOUNT_SEED;
 
+pub use self::betanet::Betanet;
 pub use self::info::Info;
 pub use self::mainnet::Mainnet;
 pub use self::sandbox::Sandbox;

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -2,7 +2,7 @@ mod impls;
 
 use std::sync::Arc;
 
-use crate::network::{Mainnet, Sandbox, Testnet};
+use crate::network::{Betanet, Mainnet, Sandbox, Testnet};
 use crate::Network;
 
 pub struct Worker<T> {
@@ -47,6 +47,11 @@ pub async fn mainnet() -> anyhow::Result<Worker<Mainnet>> {
 /// network, and grab a [`Worker`] that can interact with it.
 pub async fn mainnet_archival() -> anyhow::Result<Worker<Mainnet>> {
     Ok(Worker::new(Mainnet::archival().await?))
+}
+
+/// Connect to the betanet network, and grab a [`Worker`] that can interact with it.
+pub async fn betanet() -> anyhow::Result<Worker<Betanet>> {
+    Ok(Worker::new(Betanet::new().await?))
 }
 
 /// Run a locally scoped task with a [`sandbox`] instanced [`Worker`] is supplied.

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -102,3 +102,12 @@ where
 {
     Ok(task(mainnet_archival().await?).await)
 }
+
+/// Run a locally scoped task where a [`betanet`] instanced [`Worker`] is supplied.
+pub async fn with_betanet<F, T>(task: F) -> anyhow::Result<T::Output>
+where
+    F: Fn(Worker<Betanet>) -> T,
+    T: core::future::Future,
+{
+    Ok(task(betanet().await?).await)
+}


### PR DESCRIPTION
resolves https://github.com/near/workspaces-rs/issues/114.

This adds betanet support to workspaces, while the more general custom network creation is being addressed in a later PR