### PR TITLE
feat: allow patch state to take in multiple patches + access key and account patching

### DIFF
--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -104,6 +104,15 @@ async fn main() -> anyhow::Result<()> {
         )
         .await?;
 
+    // build pattern equivalent
+
+    // worker
+    //     .patch_state_builder()
+    //     .data(sandbox_contract.id(), "STATE", status_msg.try_to_vec()?)
+    //     // .data_many(sandbox_contract.id(), [("hello", "world"), ("goodbye", "putin")])
+    //     .send()
+    //     .await?;
+
     // Now grab the state to see that it has indeed been patched:
     let status: String = sandbox_contract
         .view(

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -99,8 +99,8 @@ async fn main() -> anyhow::Result<()> {
     worker
         .patch_state(
             sandbox_contract.id(),
-            "STATE".as_bytes(),
-            &status_msg.try_to_vec()?,
+            "STATE",
+            status_msg.try_to_vec()?,
         )
         .await?;
 

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
     //     .patch_state_builder()
     //     .data(sandbox_contract.id(), "STATE", status_msg.try_to_vec()?)
     //     // .data_many(sandbox_contract.id(), [("hello", "world"), ("goodbye", "putin")])
-    //     .send()
+    //     .apply()
     //     .await?;
 
     // Now grab the state to see that it has indeed been patched:

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -97,19 +97,15 @@ async fn main() -> anyhow::Result<()> {
 
     // Patch our testnet STATE into our local sandbox:
     worker
-        .patch_state(
-            sandbox_contract.id(),
-            "STATE",
-            status_msg.try_to_vec()?,
-        )
+        .patch_state(sandbox_contract.id(), "STATE", status_msg.try_to_vec()?)
         .await?;
 
     // build pattern equivalent
 
     // worker
-    //     .patch_state_builder()
-    //     .data(sandbox_contract.id(), "STATE", status_msg.try_to_vec()?)
-    //     // .data_many(sandbox_contract.id(), [("hello", "world"), ("goodbye", "putin")])
+    //     .patch_state_builder(sandbox_contract.id())
+    //     .data( "STATE", status_msg.try_to_vec()?)
+    //     // .data_multiple([("hello", "world"), ("goodbye", "putin")])
     //     .apply()
     //     .await?;
 

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -100,15 +100,6 @@ async fn main() -> anyhow::Result<()> {
         .patch_state(sandbox_contract.id(), "STATE", status_msg.try_to_vec()?)
         .await?;
 
-    // build pattern equivalent
-
-    // worker
-    //     .patch_state_builder(sandbox_contract.id())
-    //     .data( "STATE", status_msg.try_to_vec()?)
-    //     // .data_multiple([("hello", "world"), ("goodbye", "putin")])
-    //     .apply()
-    //     .await?;
-
     // Now grab the state to see that it has indeed been patched:
     let status: String = sandbox_contract
         .view(

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
     if !doc_build && cfg!(feature = "install") {
-        near_sandbox_utils::install().expect("Could not install sandbox");
+        // using unwrap because all the useful error messages are hidden inside
+        near_sandbox_utils::ensure_sandbox_bin().unwrap();
+        // previously the next line was causing near sandbox to be installed every time cargo build/check was called
+        // near_sandbox_utils::install().expect("Could not install sandbox");
     }
 }

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -10,8 +10,9 @@ mod server;
 mod testnet;
 pub(crate) mod variants;
 
+pub(crate) use sandbox::SandboxPatchStateAccountBuilder; //not needed directly outside of the crate
+pub(crate) use sandbox::SandboxPatchStateBuilder; //not needed directly outside of the crate
 pub(crate) use variants::DEV_ACCOUNT_SEED;
-pub(crate) use sandbox::SandboxPatchStateBuilder; //not needed directly outside of the crate 
 
 pub use betanet::Betanet;
 pub use info::Info;

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -11,12 +11,13 @@ mod testnet;
 pub(crate) mod variants;
 
 pub(crate) use variants::DEV_ACCOUNT_SEED;
+pub(crate) use sandbox::SandboxPatchStateBuilder; //not needed directly outside of the crate 
 
-pub use self::betanet::Betanet;
-pub use self::info::Info;
-pub use self::mainnet::Mainnet;
-pub use self::sandbox::Sandbox;
-pub use self::testnet::Testnet;
-pub use self::variants::{
+pub use betanet::Betanet;
+pub use info::Info;
+pub use mainnet::Mainnet;
+pub use sandbox::Sandbox;
+pub use testnet::Testnet;
+pub use variants::{
     AllowDevAccountCreation, DevAccountDeployer, NetworkClient, NetworkInfo, TopLevelAccountCreator,
 };

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -170,9 +170,7 @@ pub struct SandboxPatchStateBuilder<'s> {
     records: Vec<StateRecord>,
 }
 
-//todo: add more methods
 impl<'s> SandboxPatchStateBuilder<'s> {
-    //AsRef allows for both &AccountId and AccountId
     pub fn new(sandbox: &'s Sandbox, account_id: AccountId) -> Self {
         SandboxPatchStateBuilder {
             sandbox,
@@ -219,10 +217,6 @@ impl<'s> SandboxPatchStateBuilder<'s> {
         self
     }
 
-    // pub fn account(self) -> SandboxPatchStateAccountBuilder<'s> {
-    //     SandboxPatchStateAccountBuilder::new(self)
-    // }
-
     pub async fn apply(self) -> anyhow::Result<()> {
         let records = self.records;
         // NOTE: RpcSandboxPatchStateResponse is an empty struct with no fields, so don't do anything with it:
@@ -260,10 +254,6 @@ impl<'s> SandboxPatchStateAccountBuilder<'s> {
     }
 
     pub const fn amount(mut self, amount: Balance) -> Self {
-        // a little experiment, wonder if it can produce compile-time errors
-        if let Some(_amount) = self.amount {
-            panic!("'amount' field has already been set");
-        }
         self.amount = Some(amount);
         self
     }

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -153,7 +153,7 @@ impl Sandbox {
 }
 
 //todo: review naming
-#[must_use = "don't forget to .send() this `PatchStateBuilder`"]
+#[must_use = "don't forget to .apply() this `PatchStateBuilder`"]
 pub struct SandboxPatchStateBuilder<'s> {
     sandbox: &'s Sandbox,
     records: Vec<StateRecord>,
@@ -198,7 +198,7 @@ impl<'s> SandboxPatchStateBuilder<'s> {
         self
     }
 
-    pub async fn send(self) -> anyhow::Result<()> {
+    pub async fn apply(self) -> anyhow::Result<()> {
         let records = self.records;
         // NOTE: RpcSandboxPatchStateResponse is an empty struct with no fields, so don't do anything with it:
         let _patch_resp = self

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -177,8 +177,8 @@ impl Worker<Sandbox> {
     /// Patch state into the sandbox network, using builder pattern. This will allow us to set
     /// state that we have acquired in some manner. This allows us to test random cases that
     /// are hard to come up naturally as state evolves.
-    pub fn patch_state_builder(&self) -> SandboxPatchStateBuilder {
-        self.workspace.patch_state()
+    pub fn patch_state_builder(&self, account_id: &AccountId) -> SandboxPatchStateBuilder {
+        self.workspace.patch_state(account_id.clone())
     }
 
     /// Patch state into the sandbox network, given a key and value. This will allow us to set
@@ -191,8 +191,8 @@ impl Worker<Sandbox> {
         value: impl Into<Vec<u8>>,
     ) -> anyhow::Result<()> {
         self.workspace
-            .patch_state()
-            .data(contract_id, key, value)
+            .patch_state(contract_id.clone())
+            .data(key, value)
             .apply()
             .await?;
         Ok(())
@@ -200,17 +200,15 @@ impl Worker<Sandbox> {
 
     //todo: add more patch state methods like the previous one
 
-    /// Patch state into the sandbox network, given a sequence of key value pairs. This will allow us to set
-    /// state that we have acquired in some manner. This allows us to test random cases that
-    /// are hard to come up naturally as state evolves.
-    pub async fn patch_state_many(
+    /// Patch state into the sandbox network. Same as `patch_state` but accepts a sequence of key value pairs
+    pub async fn patch_state_multiple(
         &self,
         contract_id: &AccountId,
         kvs: impl IntoIterator<Item = (impl Into<Vec<u8>>, impl Into<Vec<u8>>)>,
     ) -> anyhow::Result<()> {
         self.workspace
-            .patch_state()
-            .data_many(contract_id, kvs)
+            .patch_state(contract_id.clone())
+            .data_many(kvs)
             .apply()
             .await?;
         Ok(())

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -193,7 +193,7 @@ impl Worker<Sandbox> {
         self.workspace
             .patch_state()
             .data(contract_id, key, value)
-            .send()
+            .apply()
             .await?;
         Ok(())
     }
@@ -211,7 +211,7 @@ impl Worker<Sandbox> {
         self.workspace
             .patch_state()
             .data_many(contract_id, kvs)
-            .send()
+            .apply()
             .await?;
         Ok(())
     }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -180,8 +180,8 @@ impl Worker<Sandbox> {
     pub async fn patch_state(
         &self,
         contract_id: &AccountId,
-        key: &[u8],
-        value: &[u8],
+        key: impl Into<Vec<u8>>,
+        value: impl Into<Vec<u8>>,
     ) -> anyhow::Result<()> {
         self.workspace.patch_state(contract_id, key, value).await
     }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -200,7 +200,7 @@ impl Worker<Sandbox> {
 
     //todo: add more patch state methods like the previous one
 
-    /// Patch state into the sandbox network, given a key and value. This will allow us to set
+    /// Patch state into the sandbox network, given a sequence of key value pairs. This will allow us to set
     /// state that we have acquired in some manner. This allows us to test random cases that
     /// are hard to come up naturally as state evolves.
     pub async fn patch_state_many(

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -91,3 +91,18 @@ async fn test_patch_state() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test(tokio::test)]
+#[ignore]
+async fn patch_state_builder() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox().await?;
+    let id: AccountId = "nino.near".parse()?;
+    worker
+        .patch_account(&id)
+        .amount(1)
+        .locked(0)
+        .apply()
+        .await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Hi, I'm working on #12 and #19. Now I feel like some review of what I've done would be great, please tell me what API is preferable and how to shape it (where to put stuff etc.).

Highlights:
* Improve over #80 
now accepting wider variety of types by using `Into<Vec<u8>>`
```rust
    pub async fn patch_state(
        &self,
        contract_id: &AccountId,
        key: impl Into<Vec<u8>>,
        value: impl Into<Vec<u8>>,
    )
```
* Implemented #12 
```rust
    pub async fn patch_state_multiple(
        &self,
        account_id: &AccountId,
        kvs: impl IntoIterator<Item = (impl Into<Vec<u8>>, impl Into<Vec<u8>>)>,
    )
```
* Implemented #19  by adapting #122 to be a builder
(for more see line 235 of sandbox.rs)
```rust
    /// Patch account state using builder pattern
    pub fn patch_account(&self, account_id: &AccountId) -> SandboxPatchStateAccountBuilder {
        self.workspace.patch_account(account_id.clone())
    }
```

Now I'm looking for some feedback to refine API :slightly_smiling_face: 