### PR TITLE
chore: bump sandbox version default for SDK change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [unreleased]
 
+### Changed
+- Updated default sandbox version to `1.26.0-rc.2` of nearcore
+
 ## [0.2.1] - 2022-04-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [unreleased]
 
 ### Changed
-- Updated default sandbox version to `1.26.0-rc.2` of nearcore
+- Updated default sandbox version to `97c0410de519ecaca369aaee26f0ca5eb9e7de06` commit of nearcore to include 1.26 protocol changes
 
 ## [0.2.1] - 2022-04-12
 

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
     if !doc_build && cfg!(feature = "install") {
-        near_sandbox_utils::install_with_version("1.26.0/57b6ac92b0e77deade8a6eef1a322272511aa5de").expect("Could not install sandbox");
+        near_sandbox_utils::install_with_version("1.26.0/57b6ac92b0e77deade8a6eef1a322272511aa5de")
+            .expect("Could not install sandbox");
     }
 }

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,7 +1,8 @@
 fn main() {
     let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
     if !doc_build && cfg!(feature = "install") {
-        near_sandbox_utils::install_with_version("1.26.0/57b6ac92b0e77deade8a6eef1a322272511aa5de")
+        // TODO Update commit to stable version once binaries are published correctly
+        near_sandbox_utils::install_with_version("master/97c0410de519ecaca369aaee26f0ca5eb9e7de06")
             .expect("Could not install sandbox");
     }
 }

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
     if !doc_build && cfg!(feature = "install") {
-        near_sandbox_utils::install().expect("Could not install sandbox");
+        near_sandbox_utils::install_with_version("1.26.0/57b6ac92b0e77deade8a6eef1a322272511aa5de").expect("Could not install sandbox");
     }
 }


### PR DESCRIPTION
commit is `1.26.0-rc.2` for now -- tested it works against https://github.com/near/near-sdk-rs/pull/742