### PR TITLE
fix: error if sandbox process has already started

### DIFF
--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -25,6 +25,10 @@ impl SandboxServer {
     }
 
     pub fn start(&mut self) -> anyhow::Result<()> {
+        if self.process.is_some() {
+            anyhow::bail!("Sandbox server already started");
+        }
+
         info!(target: "workspaces", "Starting up sandbox at localhost:{}", self.rpc_port);
         let home_dir = Sandbox::home_dir(self.rpc_port);
 


### PR DESCRIPTION
Not sure if this is intentional, opening PR more as a question of why this is the case that the process handle can get overwritten here