### PR TITLE
chore: bump workspaces patch version and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## [unreleased]
+## [Unreleased]
+
+## [0.3.0] - 2022-05-10
+
+### Added
+- Added betanet support https://github.com/near/workspaces-rs/pull/116
 
 ### Changed
-- Added betanet support https://github.com/near/workspaces-rs/pull/116
 - Updated default sandbox version to `97c0410de519ecaca369aaee26f0ca5eb9e7de06` commit of nearcore to include 1.26 protocol changes https://github.com/near/workspaces-rs/pull/134
 
 ## [0.2.1] - 2022-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [unreleased]
 
 ### Changed
-- Updated default sandbox version to `97c0410de519ecaca369aaee26f0ca5eb9e7de06` commit of nearcore to include 1.26 protocol changes
+- Added betanet support https://github.com/near/workspaces-rs/pull/116
+- Updated default sandbox version to `97c0410de519ecaca369aaee26f0ca5eb9e7de06` commit of nearcore to include 1.26 protocol changes https://github.com/near/workspaces-rs/pull/134
 
 ## [0.2.1] - 2022-04-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@
 - Fix race condition when installing sandbox and running multiples tests at the same time. https://github.com/near/workspaces-rs/pull/46
 
 
-[Unreleased]: https://github.com/near/workspaces-rs/compare/0.2.1...HEAD
+[Unreleased]: https://github.com/near/workspaces-rs/compare/0.3.0...HEAD
+[0.3.0]: https://github.com/near/workspaces-rs/compare/0.2.1...0.3.0
 [0.2.1]: https://github.com/near/workspaces-rs/compare/0.2.0...0.2.1
 [0.2.0]: https://github.com/near/workspaces-rs/compare/0.1.1...0.2.0
 [0.1.1]: https://github.com/near/workspaces-rs/compare/0.1.0...0.1.1

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspaces"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
Only opinionated thing about this is if the betanet addition should be under an unstable feature flag, but likely the version bump should be minor anyway since sandbox default protocol change shouldn't be a patch version