### PR TITLE
chore: add secret key creation methods and added new KeyType type

### DIFF
--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -9,13 +9,13 @@ mod cargo;
 pub use cargo::compile_project;
 
 mod rpc;
-mod types;
 mod worker;
 
 pub mod network;
 pub mod operations;
 pub mod prelude;
 pub mod result;
+pub mod types;
 
 pub use network::variants::{DevNetwork, Network};
 pub use types::account::{Account, AccountDetails, Contract};

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -4,11 +4,12 @@ use crate::result::{CallExecution, CallExecutionDetails, ViewResultDetails};
 use crate::rpc::client::{
     send_batch_tx_and_retry, Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS,
 };
-use crate::types::{AccessKey, AccountId, Balance, Gas, InMemorySigner, PublicKey, SecretKey};
+use crate::types::{
+    AccessKey, AccountId, Balance, Gas, InMemorySigner, KeyType, PublicKey, SecretKey,
+};
 use crate::worker::Worker;
-use crate::Account;
-use crate::Network;
-use near_crypto::KeyType;
+use crate::{Account, Network};
+
 use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
     DeployContractAction, FunctionCallAction, StakeAction, TransferAction,

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -1,11 +1,10 @@
-use near_crypto::KeyType;
 use near_jsonrpc_client::methods::sandbox_patch_state::RpcSandboxPatchStateRequest;
 use near_primitives::types::BlockId;
 use near_primitives::{account::AccessKey, state_record::StateRecord, types::Balance};
 
 use crate::network::DEV_ACCOUNT_SEED;
 use crate::rpc::client::Client;
-use crate::types::{BlockHeight, SecretKey};
+use crate::types::{BlockHeight, KeyType, SecretKey};
 use crate::{AccountId, Contract, CryptoHash, InMemorySigner};
 
 /// A [`Transaction`]-like object that allows us to specify details about importing

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -9,7 +9,7 @@ use std::fmt;
 use std::path::Path;
 
 pub use near_account_id::AccountId;
-pub(crate) use near_crypto::{KeyType, Signer};
+pub(crate) use near_crypto::Signer;
 use near_primitives::logging::pretty_hash;
 use near_primitives::serialize::{from_base, to_base};
 use serde::{Deserialize, Serialize};
@@ -28,25 +28,79 @@ pub type Balance = u128;
 /// Height of a specific block
 pub type BlockHeight = u64;
 
+/// Key types supported for either a [`SecretKey`] or [`PublicKey`]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum KeyType {
+    ED25519,
+    SECP256K1,
+}
+
+impl From<KeyType> for near_crypto::KeyType {
+    fn from(key_type: KeyType) -> Self {
+        match key_type {
+            KeyType::ED25519 => Self::ED25519,
+            KeyType::SECP256K1 => Self::SECP256K1,
+        }
+    }
+}
+
+impl From<near_crypto::KeyType> for KeyType {
+    fn from(key_type: near_crypto::KeyType) -> Self {
+        match key_type {
+            near_crypto::KeyType::ED25519 => Self::ED25519,
+            near_crypto::KeyType::SECP256K1 => Self::SECP256K1,
+        }
+    }
+}
+
 impl From<PublicKey> for near_crypto::PublicKey {
     fn from(pk: PublicKey) -> Self {
         pk.0
     }
 }
 
-#[derive(Clone, Serialize, Deserialize)]
+/// Public key of an account on chain. Usually created along with a [`SecretKey`]
+/// to form a keypair associated to the account.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PublicKey(pub(crate) near_crypto::PublicKey);
 
-#[derive(Clone, Serialize, Deserialize)]
+impl PublicKey {
+    pub fn key_type(&self) -> KeyType {
+        self.0.key_type().into()
+    }
+}
+
+/// Secret key of an account on chain. Usually created along with a [`PublicKey`]
+/// to form a keypair associated to the account. To generate a new keypair, use
+/// one of the creation methods found here, such as [`SecretKey::from_seed`]
+#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SecretKey(near_crypto::SecretKey);
 
 impl SecretKey {
+    pub fn key_type(&self) -> KeyType {
+        self.0.key_type().into()
+    }
+
     pub fn public_key(&self) -> PublicKey {
         PublicKey(self.0.public_key())
     }
 
     pub fn from_seed(key_type: KeyType, seed: &str) -> Self {
-        Self(near_crypto::SecretKey::from_seed(key_type, seed))
+        Self(near_crypto::SecretKey::from_seed(key_type.into(), seed))
+    }
+
+    pub fn from_random(key_type: KeyType) -> Self {
+        Self(near_crypto::SecretKey::from_random(key_type.into()))
+    }
+}
+
+impl std::str::FromStr for SecretKey {
+    // FIXME: deferred specific error impl to https://github.com/near/workspaces-rs/issues/100
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> anyhow::Result<Self> {
+        Ok(Self(near_crypto::SecretKey::from_str(value)?))
     }
 }
 

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -36,17 +36,15 @@ pub enum KeyType {
     SECP256K1,
 }
 
-impl From<KeyType> for near_crypto::KeyType {
-    fn from(key_type: KeyType) -> Self {
-        match key_type {
-            KeyType::ED25519 => Self::ED25519,
-            KeyType::SECP256K1 => Self::SECP256K1,
+impl KeyType {
+    const fn into_near_keytype(self) -> near_crypto::KeyType {
+        match self {
+            Self::ED25519 => near_crypto::KeyType::ED25519,
+            Self::SECP256K1 => near_crypto::KeyType::SECP256K1,
         }
     }
-}
 
-impl From<near_crypto::KeyType> for KeyType {
-    fn from(key_type: near_crypto::KeyType) -> Self {
+    const fn from_near_keytype(key_type: near_crypto::KeyType) -> Self {
         match key_type {
             near_crypto::KeyType::ED25519 => Self::ED25519,
             near_crypto::KeyType::SECP256K1 => Self::SECP256K1,
@@ -62,24 +60,24 @@ impl From<PublicKey> for near_crypto::PublicKey {
 
 /// Public key of an account on chain. Usually created along with a [`SecretKey`]
 /// to form a keypair associated to the account.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct PublicKey(pub(crate) near_crypto::PublicKey);
 
 impl PublicKey {
     pub fn key_type(&self) -> KeyType {
-        self.0.key_type().into()
+        KeyType::from_near_keytype(self.0.key_type())
     }
 }
 
 /// Secret key of an account on chain. Usually created along with a [`PublicKey`]
 /// to form a keypair associated to the account. To generate a new keypair, use
 /// one of the creation methods found here, such as [`SecretKey::from_seed`]
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SecretKey(near_crypto::SecretKey);
 
 impl SecretKey {
     pub fn key_type(&self) -> KeyType {
-        self.0.key_type().into()
+        KeyType::from_near_keytype(self.0.key_type())
     }
 
     pub fn public_key(&self) -> PublicKey {
@@ -87,11 +85,13 @@ impl SecretKey {
     }
 
     pub fn from_seed(key_type: KeyType, seed: &str) -> Self {
-        Self(near_crypto::SecretKey::from_seed(key_type.into(), seed))
+        let key_type = key_type.into_near_keytype();
+        Self(near_crypto::SecretKey::from_seed(key_type, seed))
     }
 
     pub fn from_random(key_type: KeyType) -> Self {
-        Self(near_crypto::SecretKey::from_random(key_type.into()))
+        let key_type = key_type.into_near_keytype();
+        Self(near_crypto::SecretKey::from_random(key_type))
     }
 }
 

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -1,0 +1,31 @@
+use workspaces::types::{KeyType, SecretKey};
+
+#[test]
+fn test_keypair_ed25519() -> anyhow::Result<()> {
+    let pk_expected = "\"ed25519:DcA2MzgpJbrUATQLLceocVckhhAqrkingax4oJ9kZ847\"";
+    let sk_expected = "\"ed25519:3KyUuch8pYP47krBq4DosFEVBMR5wDTMQ8AThzM8kAEcBQEpsPdYTZ2FPX5ZnSoLrerjwg66hwwJaW1wHzprd5k3\"";
+
+    let sk = SecretKey::from_seed(KeyType::ED25519, "test");
+    let pk = sk.public_key();
+    assert_eq!(serde_json::to_string(&pk)?, pk_expected);
+    assert_eq!(serde_json::to_string(&sk)?, sk_expected);
+    assert_eq!(pk, serde_json::from_str(pk_expected)?);
+    assert_eq!(sk, serde_json::from_str(sk_expected)?);
+
+    Ok(())
+}
+
+#[test]
+fn test_keypair_secp256k1() -> anyhow::Result<()> {
+    let pk_expected = "\"secp256k1:BtJtBjukUQbcipnS78adSwUKE38sdHnk7pTNZH7miGXfodzUunaAcvY43y37nm7AKbcTQycvdgUzFNWsd7dgPZZ\"";
+    let sk_expected = "\"secp256k1:9ZNzLxNff6ohoFFGkbfMBAFpZgD7EPoWeiuTpPAeeMRV\"";
+
+    let sk = SecretKey::from_seed(KeyType::SECP256K1, "test");
+    let pk = sk.public_key();
+    assert_eq!(serde_json::to_string(&pk)?, pk_expected);
+    assert_eq!(serde_json::to_string(&sk)?, sk_expected);
+    assert_eq!(pk, serde_json::from_str(pk_expected)?);
+    assert_eq!(sk, serde_json::from_str(sk_expected)?);
+
+    Ok(())
+}


### PR DESCRIPTION
addresses https://github.com/near/workspaces-rs/issues/130

`SecretKey` now has two new creation methods:
- `from_random`
- `from_str`

~Somewhat breaking API if anyone used `SecretKey::from_seed`, since this PR swapped `near_crypto::KeyType` for `workspaces::types::KeyType`~

edit: nevermind about breaking API, `types` module was never exposed