### PR TITLE
chore: Expose account keys

### DIFF
--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use near_primitives::views::AccountView;
 
-use crate::types::{AccountId, Balance, InMemorySigner};
+use crate::types::{AccountId, Balance, InMemorySigner, SecretKey};
 use crate::{CryptoHash, Network, Worker};
 
 use crate::operations::{CallTransaction, CreateAccountTransaction, Transaction};
@@ -146,6 +146,11 @@ impl Account {
         crate::rpc::tool::write_cred_to_file(&savepath, &self.id, &self.signer.0.secret_key);
 
         Ok(())
+    }
+
+    /// Get the keys of this account. The public key can be retrieved from the secret key.
+    pub fn keys(&self) -> SecretKey {
+        SecretKey(self.signer.0.secret_key.clone())
     }
 }
 

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -21,7 +21,7 @@ impl Account {
     /// Create a new account with the given path to the credentials JSON file
     pub fn from_file(path: impl AsRef<std::path::Path>) -> Self {
         let signer = InMemorySigner::from_file(path.as_ref());
-        let id = signer.0.account_id.clone();
+        let id = signer.account_id.clone();
         Self::new(id, signer)
     }
 
@@ -143,14 +143,14 @@ impl Account {
         let mut savepath = savepath.join(self.id.to_string());
         savepath.set_extension("json");
 
-        crate::rpc::tool::write_cred_to_file(&savepath, &self.id, &self.signer.0.secret_key);
+        crate::rpc::tool::write_cred_to_file(&savepath, &self.id, &self.secret_key().0);
 
         Ok(())
     }
 
     /// Get the keys of this account. The public key can be retrieved from the secret key.
-    pub fn keys(&self) -> SecretKey {
-        SecretKey(self.signer.0.secret_key.clone())
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.signer.secret_key
     }
 }
 

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -73,7 +73,7 @@ impl PublicKey {
 /// to form a keypair associated to the account. To generate a new keypair, use
 /// one of the creation methods found here, such as [`SecretKey::from_seed`]
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SecretKey(near_crypto::SecretKey);
+pub struct SecretKey(pub(crate) near_crypto::SecretKey);
 
 impl SecretKey {
     pub fn key_type(&self) -> KeyType {


### PR DESCRIPTION
Addresses https://github.com/near/workspaces-rs/issues/142

Exposes the account keys. Might be a little weird that it's exposed just as a `SecretKey` type instead of something like a `KeyPair` type. This is due to `SecretKey` being a `KeyPair` itself containing the `PublicKey`. WDYT? Is the return type good enough just as `SecretKey` or should we do something like `(PublicKey, SecretKey)`?