### PR TITLE
fix: avoid creating new client for every request & hyper issues

### DIFF
--- a/workspaces/src/network/betanet.rs
+++ b/workspaces/src/network/betanet.rs
@@ -22,7 +22,7 @@ pub struct Betanet {
 
 impl Betanet {
     pub(crate) async fn new() -> anyhow::Result<Self> {
-        let client = Client::new(RPC_URL.into());
+        let client = Client::new(RPC_URL);
         client.wait_for_rpc().await?;
 
         Ok(Self {

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -22,7 +22,7 @@ pub struct Mainnet {
 
 impl Mainnet {
     pub(crate) async fn new() -> anyhow::Result<Self> {
-        let client = Client::new(RPC_URL.into());
+        let client = Client::new(RPC_URL);
         client.wait_for_rpc().await?;
 
         Ok(Self {
@@ -37,7 +37,7 @@ impl Mainnet {
     }
 
     pub(crate) async fn archival() -> anyhow::Result<Self> {
-        let client = Client::new(ARCHIVAL_URL.into());
+        let client = Client::new(ARCHIVAL_URL);
         client.wait_for_rpc().await?;
 
         Ok(Self {

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -48,7 +48,7 @@ impl Sandbox {
     pub(crate) async fn new() -> anyhow::Result<Self> {
         let mut server = SandboxServer::default();
         server.start()?;
-        let client = Client::new(server.rpc_addr());
+        let client = Client::new(&server.rpc_addr());
         client.wait_for_rpc().await?;
 
         let info = Info {

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -31,7 +31,7 @@ pub struct Testnet {
 
 impl Testnet {
     pub(crate) async fn new() -> anyhow::Result<Self> {
-        let client = Client::new(RPC_URL.into());
+        let client = Client::new(RPC_URL);
         client.wait_for_rpc().await?;
 
         Ok(Self {
@@ -46,7 +46,7 @@ impl Testnet {
     }
 
     pub(crate) async fn archival() -> anyhow::Result<Self> {
-        let client = Client::new(ARCHIVAL_URL.into());
+        let client = Client::new(ARCHIVAL_URL);
         client.wait_for_rpc().await?;
 
         Ok(Self {

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -34,6 +34,7 @@ const ERR_INVALID_VARIANT: &str =
 /// A client that wraps around [`JsonRpcClient`], and provides more capabilities such
 /// as retry w/ exponential backoff and utility functions for sending transactions.
 pub struct Client {
+    rpc_addr: String,
     rpc_client: JsonRpcClient,
 }
 
@@ -41,6 +42,7 @@ impl Client {
     pub(crate) fn new(rpc_addr: &str) -> Self {
         Self {
             rpc_client: JsonRpcClient::connect(rpc_addr),
+            rpc_addr: rpc_addr.into(),
         }
     }
 
@@ -356,7 +358,8 @@ impl Client {
     }
 
     pub(crate) async fn status(&self) -> Result<StatusResponse, JsonRpcError<RpcStatusError>> {
-        let result = JsonRpcClient::connect(&self.rpc_addr)
+        let result = self
+            .rpc_client
             .call(methods::status::RpcStatusRequest)
             .await;
 

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -40,8 +40,11 @@ pub struct Client {
 
 impl Client {
     pub(crate) fn new(rpc_addr: &str) -> Self {
+        let connector = JsonRpcClient::new_client();
+        let rpc_client = connector.connect(rpc_addr);
+
         Self {
-            rpc_client: JsonRpcClient::connect(rpc_addr),
+            rpc_client,
             rpc_addr: rpc_addr.into(),
         }
     }


### PR DESCRIPTION
basing this one off of https://github.com/near/workspaces-rs/pull/105 since we never got to pull it in. This also includes a fix for hyper related: `dispatch dropped without returning error`. The git diff looks horrendous trying to merge into the original PR due to rebasing/squashing, so this one would be faster to just push in