### PR TITLE
chore: Update Deps Along w/ M1 Support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
     - name: Check with stable features
       run: cargo check --verbose
     - name: Run tests with unstable features
-      run: NEAR_RPC_TIMEOUT_SECS=30 cargo test --verbose --features unstable
+      run: NEAR_RPC_TIMEOUT_SECS=100 cargo test --verbose --features unstable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,4 @@ jobs:
     - name: Check with stable features
       run: cargo check --verbose
     - name: Run tests with unstable features
-      run: cargo test --verbose --features unstable
+      run: NEAR_RPC_TIMEOUT_SECS=30 cargo test --verbose --features unstable

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -203,7 +203,7 @@ async fn create_custom_ft(
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let worker = workspaces::sandbox().await?;
-    let owner = worker.root_account();
+    let owner = worker.root_account()?;
 
     ///////////////////////////////////////////////////////////////////////////
     // Stage 1: Deploy relevant contracts such as FT, WNear, and Ref-Finance

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -29,11 +29,11 @@ tokio-retry = "0.3"
 tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
 
-near-account-id = "0.12.0"
-near-crypto = "0.12.0"
-near-primitives = "0.12.0"
-near-jsonrpc-primitives = "0.12.0"
-near-jsonrpc-client = { version = "0.3.0", features = ["sandbox"] }
+near-account-id = "0.14.0"
+near-crypto = "0.14.0"
+near-primitives = "0.14.0"
+near-jsonrpc-primitives = "0.14.0"
+near-jsonrpc-client = { version = "0.4.0-beta.0", features = ["sandbox"] }
 near-sandbox-utils = "0.2.0"
 
 [build-dependencies]

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -34,17 +34,17 @@ near-crypto = "0.14.0"
 near-primitives = "0.14.0"
 near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = { version = "0.4.0-beta.0", features = ["sandbox"] }
-near-sandbox-utils = "0.2.0"
+near-sandbox-utils = "0.4.0-pre.1"
 
 [build-dependencies]
-near-sandbox-utils = "0.2.0"
+near-sandbox-utils = "0.4.0-pre.1"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
 [dev-dependencies]
 borsh = "0.9"
-near-units = "0.1.0"
+near-units = "0.2.0"
 near-sdk = "4.0.0-pre.7"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -45,7 +45,7 @@ libc = "0.2"
 [dev-dependencies]
 borsh = "0.9"
 near-units = "0.2.0"
-near-sdk = "4.0.0-pre.7"
+near-sdk = "4.0.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -34,10 +34,10 @@ near-crypto = "0.14.0"
 near-primitives = "0.14.0"
 near-jsonrpc-primitives = "0.14.0"
 near-jsonrpc-client = { version = "0.4.0-beta.0", features = ["sandbox"] }
-near-sandbox-utils = "0.4.0-pre.1"
+near-sandbox-utils = "0.4.0"
 
 [build-dependencies]
-near-sandbox-utils = "0.4.0-pre.1"
+near-sandbox-utils = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -3,7 +3,6 @@ fn main() {
     let env_bin = std::env::var("NEAR_SANDBOX_BIN_PATH").is_ok();
     if !doc_build && !env_bin && cfg!(feature = "install") {
         // TODO Update commit to stable version once binaries are published correctly
-        near_sandbox_utils::install_with_version("master/97c0410de519ecaca369aaee26f0ca5eb9e7de06")
-            .expect("Could not install sandbox");
+        near_sandbox_utils::install().expect("Could not install sandbox");
     }
 }

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
-    if !doc_build && cfg!(feature = "install") {
+    let env_bin = std::env::var("NEAR_SANDBOX_BIN_PATH").is_ok();
+    if !doc_build && !env_bin && cfg!(feature = "install") {
         // TODO Update commit to stable version once binaries are published correctly
         near_sandbox_utils::install_with_version("master/97c0410de519ecaca369aaee26f0ca5eb9e7de06")
             .expect("Could not install sandbox");

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=NEAR_SANDBOX_BIN_PATH");
+
     let doc_build = cfg!(doc) || std::env::var("DOCS_RS").is_ok();
     let env_bin = std::env::var("NEAR_SANDBOX_BIN_PATH").is_ok();
     if !doc_build && !env_bin && cfg!(feature = "install") {

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -38,7 +38,7 @@ impl Sandbox {
         path
     }
 
-    pub(crate) fn root_signer(&self) -> InMemorySigner {
+    pub(crate) fn root_signer(&self) -> anyhow::Result<InMemorySigner> {
         let mut path = Self::home_dir(self.server.rpc_port);
         path.push("validator_key.json");
 
@@ -91,7 +91,7 @@ impl TopLevelAccountCreator for Sandbox {
         id: AccountId,
         sk: SecretKey,
     ) -> anyhow::Result<CallExecution<Account>> {
-        let root_signer = self.root_signer();
+        let root_signer = self.root_signer()?;
         let outcome = self
             .client
             .create_account(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT)
@@ -110,7 +110,7 @@ impl TopLevelAccountCreator for Sandbox {
         sk: SecretKey,
         wasm: &[u8],
     ) -> anyhow::Result<CallExecution<Contract>> {
-        let root_signer = self.root_signer();
+        let root_signer = self.root_signer()?;
         let outcome = self
             .client
             .create_account_and_deploy(

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -27,10 +27,10 @@ impl fmt::Debug for Account {
 
 impl Account {
     /// Create a new account with the given path to the credentials JSON file
-    pub fn from_file(path: impl AsRef<std::path::Path>) -> Self {
-        let signer = InMemorySigner::from_file(path.as_ref());
+    pub fn from_file(path: impl AsRef<std::path::Path>) -> anyhow::Result<Self> {
+        let signer = InMemorySigner::from_file(path.as_ref())?;
         let id = signer.account_id.clone();
-        Self::new(id, signer)
+        Ok(Self::new(id, signer))
     }
 
     pub(crate) fn new(id: AccountId, signer: InMemorySigner) -> Self {

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -119,7 +119,10 @@ impl InMemorySigner {
 
     pub fn from_file(path: &Path) -> anyhow::Result<Self> {
         let signer = near_crypto::InMemorySigner::from_file(path)?;
-        Ok(Self::from_secret_key(signer.account_id, SecretKey(signer.secret_key)))
+        Ok(Self::from_secret_key(
+            signer.account_id,
+            SecretKey(signer.secret_key),
+        ))
     }
 
     pub(crate) fn inner(&self) -> near_crypto::InMemorySigner {

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -117,9 +117,9 @@ impl InMemorySigner {
         }
     }
 
-    pub fn from_file(path: &Path) -> Self {
-        let signer = near_crypto::InMemorySigner::from_file(path);
-        Self::from_secret_key(signer.account_id, SecretKey(signer.secret_key))
+    pub fn from_file(path: &Path) -> anyhow::Result<Self> {
+        let signer = near_crypto::InMemorySigner::from_file(path)?;
+        Ok(Self::from_secret_key(signer.account_id, SecretKey(signer.secret_key)))
     }
 
     pub(crate) fn inner(&self) -> near_crypto::InMemorySigner {

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -160,7 +160,7 @@ impl Worker<Sandbox> {
     pub fn root_account(&self) -> Account {
         let account_id = self.info().root_id.clone();
         let signer = self.workspace.root_signer();
-        Account::new(account_id, signer)
+        Account::new(account_id, signer.unwrap())
     }
 
     /// Import a contract from the the given network, and return us a [`ImportContractTransaction`]

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -157,10 +157,10 @@ where
 }
 
 impl Worker<Sandbox> {
-    pub fn root_account(&self) -> Account {
+    pub fn root_account(&self) -> anyhow::Result<Account> {
         let account_id = self.info().root_id.clone();
-        let signer = self.workspace.root_signer();
-        Account::new(account_id, signer.unwrap())
+        let signer = self.workspace.root_signer()?;
+        Ok(Account::new(account_id, signer))
     }
 
     /// Import a contract from the the given network, and return us a [`ImportContractTransaction`]


### PR DESCRIPTION
This updates nearcore deps to the latest, and also sandbox dep where we now support M1.

Also, since updating to the latest nearcore, there seems to be a bug where the `EnvFilter` in nearcore ignores the case for `stats` target but works for others. So this is causing some stats to be logged every second. Minor annoyance, but will see what's causing it and fix it in the future on a patch release. Getting out M1 support for now in the newest minor patch is more important