### PR TITLE
fix: Parallel tests should not wait on each other

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -20,7 +20,6 @@ chrono = "0.4.19"
 dirs = "3.0.2"
 futures = "0.3"
 hex = "0.4.2"
-lazy_static = "1.4.0"
 portpicker = "0.1.1"
 rand = "0.8.4"
 reqwest = { version = "0.11", features = ["json"] }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -18,7 +18,6 @@ borsh = "0.9"
 cargo_metadata = { version = "0.14.2", optional = true }
 chrono = "0.4.19"
 dirs = "3.0.2"
-futures = "0.3"
 hex = "0.4.2"
 portpicker = "0.1.1"
 rand = "0.8.4"
@@ -46,6 +45,7 @@ libc = "0.2"
 
 [dev-dependencies]
 borsh = "0.9"
+futures = "0.3"
 near-units = "0.2.0"
 near-sdk = "4.0.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -18,7 +18,9 @@ borsh = "0.9"
 cargo_metadata = { version = "0.14.2", optional = true }
 chrono = "0.4.19"
 dirs = "3.0.2"
+futures = "0.3"
 hex = "0.4.2"
+lazy_static = "1.4.0"
 portpicker = "0.1.1"
 rand = "0.8.4"
 reqwest = { version = "0.11", features = ["json"] }

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -37,6 +37,7 @@ pub(crate) const DEFAULT_CALL_DEPOSIT: Balance = 0;
 pub struct Client {
     rpc_addr: String,
     rpc_client: JsonRpcClient,
+    /// AccessKey nonces to reference when sending transactions.
     access_key_nonces: RwLock<HashMap<AccountId, Mutex<Nonce>>>,
 }
 

--- a/workspaces/tests/parallel_transactions.rs
+++ b/workspaces/tests/parallel_transactions.rs
@@ -1,26 +1,7 @@
-use futures::future::join_all;
 use serde_json::json;
-use workspaces::{network::Sandbox, prelude::*, Account, AccountId, Worker};
+use workspaces::prelude::*;
 
 const STATUS_MSG_CONTRACT: &[u8] = include_bytes!("../../examples/res/status_message.wasm");
-
-async fn task(
-    worker: Worker<Sandbox>,
-    id: AccountId,
-    msg: &str,
-    account: &Account,
-) -> anyhow::Result<()> {
-    println!("CALLING IN: {:?} -> {}", std::thread::current().id(), msg);
-    account
-        .call(&worker, &id, "set_status")
-        .args_json(json!({
-            "message": msg,
-        }))?
-        .transact()
-        .await?;
-
-    Ok(())
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_parallel() -> anyhow::Result<()> {
@@ -28,17 +9,24 @@ async fn test_parallel() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
     let account = worker.dev_create_account().await?;
 
-    join_all(
-        ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-            .iter()
-            .map(|x| {
-                let id = contract.id().clone();
-                let worker = worker.clone();
-                let a = account.clone();
-                tokio::spawn(async move { task(worker, id, x, &a).await.unwrap() })
-            }),
-    )
-    .await;
+    let parallel_tasks = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+        .iter()
+        .map(|msg| {
+            let id = contract.id().clone();
+            let worker = worker.clone();
+            let account = account.clone();
+            tokio::spawn(async move {
+                account
+                    .call(&worker, &id, "set_status")
+                    .args_json(json!({
+                        "message": msg,
+                    }))?
+                    .transact()
+                    .await?;
+                anyhow::Result::<()>::Ok(())
+            })
+        });
+    futures::future::join_all(parallel_tasks).await;
 
     // Check the final set message. This should be random each time this test function is called:
     let final_set_msg = account

--- a/workspaces/tests/parallel_transactions.rs
+++ b/workspaces/tests/parallel_transactions.rs
@@ -8,10 +8,8 @@ async fn test_parallel() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
     let account = worker.dev_create_account().await?;
 
-    let parallel_tasks =
-        // ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-        // .iter()
-        (0..1000)
+    let parallel_tasks = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+        .iter()
         .map(|msg| {
             let id = contract.id().clone();
             let account = account.clone();

--- a/workspaces/tests/parallel_transactions.rs
+++ b/workspaces/tests/parallel_transactions.rs
@@ -1,0 +1,98 @@
+use futures::future::join_all;
+use serde_json::json;
+use workspaces::{network::Sandbox, prelude::*, Account, AccountId, Worker};
+
+const STATUS_MSG_CONTRACT: &[u8] = include_bytes!("../../examples/res/status_message.wasm");
+
+async fn task(
+    worker: Worker<Sandbox>,
+    id: AccountId,
+    msg: &str,
+    add: u64,
+    account: &Account,
+) -> anyhow::Result<()> {
+    println!("CALLING IN: {:?} -> {}", std::thread::current().id(), msg);
+    account
+        .call(&worker, &id, "set_status")
+        .args_json(json!({
+            "message": msg,
+        }))?
+        // .nonce(add)
+        .transact()
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_parallel_transactions() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox().await?;
+    let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
+    let account = worker.dev_create_account().await?;
+
+    for x in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"] {
+        let id = contract.id().clone();
+        let worker = worker.clone();
+        let a = account.clone();
+        tokio::spawn(async move { task(worker, id, x, 0, &a).await.unwrap() }).await?;
+    }
+
+    let aa = account
+        .call(&worker, contract.id(), "get_status")
+        .args_json(json!({ "account_id": account.id() }))?
+        .view()
+        .await?
+        .json::<String>()?;
+    let bb = account
+        .call(&worker, contract.id(), "get_status")
+        .args_json(json!({ "account_id": account.id() }))?
+        .view()
+        .await?
+        .json::<String>()?;
+    println!("a: {}", aa);
+    println!("b: {}", bb);
+
+    Ok(())
+}
+
+#[test]
+fn test_parallel() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_name("my-custom-name")
+        .thread_stack_size(3 * 1024 * 1024)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let _x: anyhow::Result<()> = rt.block_on(async {
+        let worker = workspaces::sandbox().await?;
+        let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
+        let account = worker.dev_create_account().await?;
+
+        join_all(
+            ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+                .iter()
+                .map(|x| {
+                    let id = contract.id().clone();
+                    let worker = worker.clone();
+                    let a = account.clone();
+                    tokio::spawn(async move { task(worker, id, x, 0, &a).await.unwrap() })
+                }),
+        )
+        .await;
+
+        let aa = account
+            .call(&worker, contract.id(), "get_status")
+            .args_json(json!({ "account_id": account.id() }))?
+            .view()
+            .await?
+            .json::<String>()?;
+
+        println!("msg: {:?}", aa);
+
+        Ok(())
+    });
+
+    Ok(())
+}

--- a/workspaces/tests/parallel_transactions.rs
+++ b/workspaces/tests/parallel_transactions.rs
@@ -8,8 +8,10 @@ async fn test_parallel() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
     let account = worker.dev_create_account().await?;
 
-    let parallel_tasks = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-        .iter()
+    let parallel_tasks =
+        // ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+        // .iter()
+        (0..1000)
         .map(|msg| {
             let id = contract.id().clone();
             let account = account.clone();
@@ -17,7 +19,7 @@ async fn test_parallel() -> anyhow::Result<()> {
                 account
                     .call(&id, "set_status")
                     .args_json(json!({
-                        "message": msg,
+                        "message": msg.to_string(),
                     }))
                     .transact()
                     .await?

--- a/workspaces/tests/parallel_transactions.rs
+++ b/workspaces/tests/parallel_transactions.rs
@@ -8,7 +8,6 @@ async fn task(
     worker: Worker<Sandbox>,
     id: AccountId,
     msg: &str,
-    add: u64,
     account: &Account,
 ) -> anyhow::Result<()> {
     println!("CALLING IN: {:?} -> {}", std::thread::current().id(), msg);
@@ -17,82 +16,38 @@ async fn task(
         .args_json(json!({
             "message": msg,
         }))?
-        // .nonce(add)
         .transact()
         .await?;
 
     Ok(())
 }
 
-#[tokio::test]
-async fn test_parallel_transactions() -> anyhow::Result<()> {
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_parallel() -> anyhow::Result<()> {
     let worker = workspaces::sandbox().await?;
     let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
     let account = worker.dev_create_account().await?;
 
-    for x in ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"] {
-        let id = contract.id().clone();
-        let worker = worker.clone();
-        let a = account.clone();
-        tokio::spawn(async move { task(worker, id, x, 0, &a).await.unwrap() }).await?;
-    }
+    join_all(
+        ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+            .iter()
+            .map(|x| {
+                let id = contract.id().clone();
+                let worker = worker.clone();
+                let a = account.clone();
+                tokio::spawn(async move { task(worker, id, x, &a).await.unwrap() })
+            }),
+    )
+    .await;
 
-    let aa = account
+    // Check the final set message. This should be random each time this test function is called:
+    let final_set_msg = account
         .call(&worker, contract.id(), "get_status")
         .args_json(json!({ "account_id": account.id() }))?
         .view()
         .await?
         .json::<String>()?;
-    let bb = account
-        .call(&worker, contract.id(), "get_status")
-        .args_json(json!({ "account_id": account.id() }))?
-        .view()
-        .await?
-        .json::<String>()?;
-    println!("a: {}", aa);
-    println!("b: {}", bb);
-
-    Ok(())
-}
-
-#[test]
-fn test_parallel() -> anyhow::Result<()> {
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(4)
-        .thread_name("my-custom-name")
-        .thread_stack_size(3 * 1024 * 1024)
-        .enable_all()
-        .build()
-        .unwrap();
-
-    let _x: anyhow::Result<()> = rt.block_on(async {
-        let worker = workspaces::sandbox().await?;
-        let contract = worker.dev_deploy(STATUS_MSG_CONTRACT).await?;
-        let account = worker.dev_create_account().await?;
-
-        join_all(
-            ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
-                .iter()
-                .map(|x| {
-                    let id = contract.id().clone();
-                    let worker = worker.clone();
-                    let a = account.clone();
-                    tokio::spawn(async move { task(worker, id, x, 0, &a).await.unwrap() })
-                }),
-        )
-        .await;
-
-        let aa = account
-            .call(&worker, contract.id(), "get_status")
-            .args_json(json!({ "account_id": account.id() }))?
-            .view()
-            .await?
-            .json::<String>()?;
-
-        println!("msg: {:?}", aa);
-
-        Ok(())
-    });
+    println!("Final set message: {:?}", final_set_msg);
 
     Ok(())
 }


### PR DESCRIPTION
This will resolve https://github.com/near/workspaces-rs/issues/163 without requiring the user to specify the nonce manually. The nonce is a value we can cache locally and only need to be retrieved once, incrementing it from thence onwards.