### PR TITLE
fix: tests erroring out on newest rust v1.63.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,17 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest]  # macos-latest disabled due to time issues w/ nearcore
+        toolchain: [stable, 1.60.0]
 
     runs-on: ${{ matrix.platform }}
     steps:
     - uses: actions/checkout@v2
+    - name: "${{ matrix.toolchain }}"
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.toolchain }}
+    - uses: Swatinem/rust-cache@v1
     - name: Add wasm32 target
       run: rustup target add wasm32-unknown-unknown
     - name: Check with stable features

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 **Release notes and unreleased changes can be found in the [CHANGELOG](CHANGELOG.md)**
 
 ## Requirements
-- Rust v1.56 and up
+- Rust v1.60.0 and up
 - MacOS (x86) or Linux (x86) for sandbox tests. Testnet is available regardless
 
 ### M1 MacOS

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -271,7 +271,7 @@ impl Contract {
 
 /// Details of an Account or Contract. This is an non-exhaustive list of items
 /// that the account stores in the blockchain state.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct AccountDetails {
     pub balance: Balance,


### PR DESCRIPTION
This fixes the current builds failing with the release of 1.63.0 with newer clippy warnings.
- also bumped MSRV to 1.60 since near-primitives 0.14 requires it.
