### PR TITLE
feat: `worker` no longer required to be passed into arguments when transacting transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 - Error handling with `workspaces::error::Error` type: https://github.com/near/workspaces-rs/pull/149
+  - breaking: `args_json` and `args_borsh` no longer return `Result`s and are deferred till later when `transact()`ed
+- breaking: No longer require `worker` to be passed in for each transaction: https://github.com/near/workspaces-rs/pull/181
+  - breaking: `Account::from_file` function signature change, requiring a `&worker` to be passed in.
+  - `workspaces::prelude::*` import no longer necessary
+    - breaking: no longer able to import `workspaces::prelude::DevAccountDeployer` directly.
 
 ## [0.4.1] - 2022-08-16
 

--- a/examples/src/croncat.rs
+++ b/examples/src/croncat.rs
@@ -10,7 +10,6 @@ use serde::Deserialize;
 use serde_json::json;
 
 use workspaces::network::Sandbox;
-use workspaces::prelude::*;
 use workspaces::{Account, AccountId, Contract, Worker};
 
 const MANAGER_CONTRACT: &[u8] = include_bytes!("../res/manager.wasm");

--- a/examples/src/fast_forward.rs
+++ b/examples/src/fast_forward.rs
@@ -16,11 +16,8 @@ async fn main() -> anyhow::Result<()> {
         .dev_deploy(&std::fs::read(SIMPLE_WASM_FILEPATH)?)
         .await?;
 
-    let (timestamp, epoch_height): (u64, u64) = contract
-        .call(&worker, "current_env_data")
-        .view()
-        .await?
-        .json()?;
+    let (timestamp, epoch_height): (u64, u64) =
+        contract.call("current_env_data").view().await?.json()?;
     println!("timestamp = {}, epoch_height = {}", timestamp, epoch_height);
 
     let block_info = worker.view_latest_block().await?;
@@ -30,11 +27,8 @@ async fn main() -> anyhow::Result<()> {
     // faster than manually waiting for the same amounts of blocks to be produced
     worker.fast_forward(10000).await?;
 
-    let (timestamp, epoch_height): (u64, u64) = contract
-        .call(&worker, "current_env_data")
-        .view()
-        .await?
-        .json()?;
+    let (timestamp, epoch_height): (u64, u64) =
+        contract.call("current_env_data").view().await?.json()?;
     println!("timestamp = {}, epoch_height = {}", timestamp, epoch_height);
 
     let block_info = worker.view_latest_block().await?;

--- a/examples/src/fast_forward.rs
+++ b/examples/src/fast_forward.rs
@@ -1,5 +1,3 @@
-use workspaces::prelude::*;
-
 /// Our simple contract. Has a function to called `current_env_data` to just grab
 /// the current block_timestamp and epoch_height. Will be used to showcase what
 /// our contracts can see pre-and-post fast forwarding.

--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -11,7 +11,7 @@ async fn main() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(&wasm).await?;
 
     let outcome = contract
-        .call(&worker, "new_default_meta")
+        .call("new_default_meta")
         .args_json(json!({
                 "owner_id": contract.id(),
         }))
@@ -22,7 +22,7 @@ async fn main() -> anyhow::Result<()> {
 
     let deposit = 10000000000000000000000;
     let outcome = contract
-        .call(&worker, "nft_mint")
+        .call("nft_mint")
         .args_json(json!({
             "token_id": "0",
             "token_owner_id": contract.id(),

--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -1,7 +1,5 @@
 use serde_json::json;
 
-use workspaces::prelude::*;
-
 const NFT_WASM_FILEPATH: &str = "./examples/res/non_fungible_token.wasm";
 
 #[tokio::main]

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -35,7 +35,7 @@ async fn create_ref(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Result
     // service to pull down (i.e. greater than 50mb).
 
     owner
-        .call(&worker, ref_finance.id(), "new")
+        .call(ref_finance.id(), "new")
         .args_json(serde_json::json!({
             "owner_id": ref_finance.id(),
             "exchange_fee": 4,
@@ -45,7 +45,7 @@ async fn create_ref(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Result
         .await?;
 
     owner
-        .call(&worker, ref_finance.id(), "storage_deposit")
+        .call(ref_finance.id(), "storage_deposit")
         .args_json(serde_json::json!({}))
         .deposit(parse_near!("30 mN"))
         .transact()
@@ -65,7 +65,7 @@ async fn create_wnear(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Resu
         .await?;
 
     owner
-        .call(&worker, wnear.id(), "new")
+        .call(wnear.id(), "new")
         .args_json(serde_json::json!({
             "owner_id": owner.id(),
             "total_supply": parse_near!("1,000,000,000 N"),
@@ -74,14 +74,14 @@ async fn create_wnear(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Resu
         .await?;
 
     owner
-        .call(&worker, wnear.id(), "storage_deposit")
+        .call(wnear.id(), "storage_deposit")
         .args_json(serde_json::json!({}))
         .deposit(parse_near!("0.008 N"))
         .transact()
         .await?;
 
     owner
-        .call(&worker, wnear.id(), "near_deposit")
+        .call(wnear.id(), "near_deposit")
         .deposit(parse_near!("200 N"))
         .transact()
         .await?;
@@ -104,13 +104,13 @@ async fn create_pool_with_liquidity(
         .unzip();
 
     ref_finance
-        .call(worker, "extend_whitelisted_tokens")
+        .call("extend_whitelisted_tokens")
         .args_json(serde_json::json!({ "tokens": token_ids }))
         .transact()
         .await?;
 
     let pool_id: u64 = ref_finance
-        .call(worker, "add_simple_pool")
+        .call("add_simple_pool")
         .args_json(serde_json::json!({
             "tokens": token_ids,
             "fee": 25
@@ -121,7 +121,7 @@ async fn create_pool_with_liquidity(
         .json()?;
 
     owner
-        .call(&worker, ref_finance.id(), "register_tokens")
+        .call(ref_finance.id(), "register_tokens")
         .args_json(serde_json::json!({
             "token_ids": token_ids,
         }))
@@ -132,7 +132,7 @@ async fn create_pool_with_liquidity(
     deposit_tokens(worker, owner, &ref_finance, tokens).await?;
 
     owner
-        .call(&worker, ref_finance.id(), "add_liquidity")
+        .call(ref_finance.id(), "add_liquidity")
         .args_json(serde_json::json!({
             "pool_id": pool_id,
             "amounts": token_amounts,
@@ -154,7 +154,7 @@ async fn deposit_tokens(
     for (contract_id, amount) in tokens {
         ref_finance
             .as_account()
-            .call(&worker, contract_id, "storage_deposit")
+            .call(contract_id, "storage_deposit")
             .args_json(serde_json::json!({
                 "registration_only": true,
             }))
@@ -163,7 +163,7 @@ async fn deposit_tokens(
             .await?;
 
         owner
-            .call(&worker, contract_id, "ft_transfer_call")
+            .call(contract_id, "ft_transfer_call")
             .args_json(serde_json::json!({
                 "receiver_id": ref_finance.id(),
                 "amount": amount.to_string(),
@@ -189,7 +189,7 @@ async fn create_custom_ft(
 
     // Initialize our FT contract with owner metadata and total supply available
     // to be traded and transfered into other contracts such as Ref-Finance
-    ft.call(&worker, "new_default_meta")
+    ft.call("new_default_meta")
         .args_json(serde_json::json!({
             "owner_id": owner.id(),
             "total_supply": parse_near!("1,000,000,000 N").to_string(),
@@ -309,7 +309,7 @@ async fn main() -> anyhow::Result<()> {
     assert_eq!(expected_return, "1662497915624478906119726");
 
     let actual_out = owner
-        .call(&worker, ref_finance.id(), "swap")
+        .call(ref_finance.id(), "swap")
         .args_json(serde_json::json!({
             "actions": vec![serde_json::json!({
                 "pool_id": pool_id,
@@ -354,7 +354,6 @@ async fn main() -> anyhow::Result<()> {
 
     let wnear_deposit: String = ref_finance
         .view(
-            &worker,
             "get_deposit",
             serde_json::json!({
                 "account_id": owner.id(),

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, convert::TryInto};
 
 use near_units::{parse_gas, parse_near};
 use workspaces::network::Sandbox;
-use workspaces::prelude::*;
 use workspaces::{Account, AccountId, Contract, Network, Worker};
 use workspaces::{BlockHeight, DevNetwork};
 

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -1,8 +1,9 @@
-use std::{collections::HashMap, convert::TryInto};
+use std::collections::HashMap;
+use std::convert::TryInto;
 
 use near_units::{parse_gas, parse_near};
 use workspaces::network::Sandbox;
-use workspaces::{Account, AccountId, Contract, Network, Worker};
+use workspaces::{Account, AccountId, Contract, Worker};
 use workspaces::{BlockHeight, DevNetwork};
 
 const FT_CONTRACT_FILEPATH: &str = "./examples/res/fungible_token.wasm";
@@ -92,7 +93,6 @@ async fn create_wnear(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Resu
 /// Add's the amount in `tokens` we set for liquidity. This will return us the
 /// pool_id after the pool has been created.
 async fn create_pool_with_liquidity(
-    worker: &Worker<impl Network>,
     owner: &Account,
     ref_finance: &Contract,
     tokens: HashMap<&AccountId, u128>,
@@ -128,7 +128,7 @@ async fn create_pool_with_liquidity(
         .transact()
         .await?;
 
-    deposit_tokens(worker, owner, &ref_finance, tokens).await?;
+    deposit_tokens(owner, &ref_finance, tokens).await?;
 
     owner
         .call(ref_finance.id(), "add_liquidity")
@@ -145,7 +145,6 @@ async fn create_pool_with_liquidity(
 
 /// Deposit tokens into Ref-Finance
 async fn deposit_tokens(
-    worker: &Worker<impl Network>,
     owner: &Account,
     ref_finance: &Contract,
     tokens: HashMap<&AccountId, u128>,
@@ -218,7 +217,6 @@ async fn main() -> anyhow::Result<()> {
     ///////////////////////////////////////////////////////////////////////////
 
     let pool_id = create_pool_with_liquidity(
-        &worker,
         &owner,
         &ref_finance,
         maplit::hashmap! {
@@ -234,7 +232,6 @@ async fn main() -> anyhow::Result<()> {
     );
 
     deposit_tokens(
-        &worker,
         &owner,
         &ref_finance,
         maplit::hashmap! {

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -3,7 +3,6 @@ use std::env;
 use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
-use workspaces::prelude::*;
 use workspaces::{AccountId, Contract, DevNetwork, Worker};
 
 const STATUS_MSG_WASM_FILEPATH: &str = "./examples/res/status_message.wasm";

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -51,7 +51,7 @@ async fn deploy_status_contract(
 
     // This will `call` into `set_status` with the message we want to set.
     contract
-        .call(worker, "set_status")
+        .call("set_status")
         .args_json(serde_json::json!({
             "message": msg,
         }))

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -107,7 +107,6 @@ async fn main() -> anyhow::Result<()> {
     // Now grab the state to see that it has indeed been patched:
     let status: String = sandbox_contract
         .view(
-            &worker,
             "get_status",
             serde_json::json!({
                 "account_id": testnet_contract_id,
@@ -124,7 +123,6 @@ async fn main() -> anyhow::Result<()> {
     // See that sandbox state was overriden. Grabbing get_status(sandbox_contract_id) should yield Null
     let result: Option<String> = sandbox_contract
         .view(
-            &worker,
             "get_status",
             serde_json::json!({
                 "account_id": sandbox_contract.id(),

--- a/examples/src/status_message.rs
+++ b/examples/src/status_message.rs
@@ -1,5 +1,4 @@
 use serde_json::json;
-use workspaces::prelude::*;
 
 const STATUS_MSG_WASM_FILEPATH: &str = "./examples/res/status_message.wasm";
 

--- a/examples/src/status_message.rs
+++ b/examples/src/status_message.rs
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(&wasm).await?;
 
     let outcome = contract
-        .call(&worker, "set_status")
+        .call("set_status")
         .args_json(json!({
             "message": "hello_world",
         }))
@@ -20,7 +20,6 @@ async fn main() -> anyhow::Result<()> {
 
     let result: String = contract
         .view(
-            &worker,
             "get_status",
             json!({
                 "account_id": contract.id(),

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -18,5 +18,5 @@ pub use self::mainnet::Mainnet;
 pub use self::sandbox::Sandbox;
 pub use self::testnet::Testnet;
 pub use self::variants::{
-    AllowDevAccountCreation, DevAccountDeployer, NetworkClient, NetworkInfo, TopLevelAccountCreator,
+    AllowDevAccountCreation, NetworkClient, NetworkInfo, TopLevelAccountCreator,
 };

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -70,7 +70,7 @@ impl std::fmt::Debug for Testnet {
     }
 }
 
-impl AllowDevAccountCreation for Worker<Testnet> {}
+impl AllowDevAccountCreation for Testnet {}
 
 #[async_trait]
 impl TopLevelAccountCreator for Testnet {

--- a/workspaces/src/network/variants.rs
+++ b/workspaces/src/network/variants.rs
@@ -39,7 +39,7 @@ pub trait DevAccountDeployer {
 }
 
 #[async_trait]
-impl<T> DevAccountDeployer for Worker<T>
+impl<T: ?Sized> DevAccountDeployer for Worker<T>
 where
     T: AllowDevAccountCreation + Send + Sync,
     Worker<T>: TopLevelAccountCreator,
@@ -73,7 +73,7 @@ impl<T> Network for T where T: NetworkInfo + NetworkClient + Send + Sync {}
 pub trait DevNetwork: AllowDevAccountCreation + Network {}
 
 // Implemented by default if we have `AllowDevAccountCreation`
-impl<T> DevNetwork for T
+impl<T: ?Sized> DevNetwork for T
 where
     Worker<T>: TopLevelAccountCreator + DevAccountDeployer,
     T: AllowDevAccountCreation + Network,

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -228,16 +228,16 @@ impl<'a> Transaction<'a> {
 
 /// Similiar to a [`Transaction`], but more specific to making a call into a contract.
 /// Note, only one call can be made per `CallTransaction`.
-pub struct CallTransaction<'a, 'b, T> {
-    worker: &'a Worker<T>,
+pub struct CallTransaction<'a, 'b> {
+    worker: &'a Worker<dyn Network>,
     signer: InMemorySigner,
     contract_id: AccountId,
     function: Function<'b>,
 }
 
-impl<'a, 'b, T: Network> CallTransaction<'a, 'b, T> {
+impl<'a, 'b> CallTransaction<'a, 'b> {
     pub(crate) fn new(
-        worker: &'a Worker<T>,
+        worker: &'a Worker<dyn Network>,
         contract_id: AccountId,
         signer: InMemorySigner,
         function: &'b str,
@@ -324,8 +324,8 @@ impl<'a, 'b, T: Network> CallTransaction<'a, 'b, T> {
 
 /// Similiar to a [`Transaction`], but more specific to creating an account.
 /// This transaction will create a new account with the specified `receiver_id`
-pub struct CreateAccountTransaction<'a, 'b, T> {
-    worker: &'a Worker<T>,
+pub struct CreateAccountTransaction<'a, 'b> {
+    worker: &'a Worker<dyn Network>,
     signer: InMemorySigner,
     parent_id: AccountId,
     new_account_id: &'b str,
@@ -334,12 +334,9 @@ pub struct CreateAccountTransaction<'a, 'b, T> {
     secret_key: Option<SecretKey>,
 }
 
-impl<'a, 'b, T> CreateAccountTransaction<'a, 'b, T>
-where
-    T: Network,
-{
+impl<'a, 'b> CreateAccountTransaction<'a, 'b> {
     pub(crate) fn new(
-        worker: &'a Worker<T>,
+        worker: &'a Worker<dyn Network>,
         signer: InMemorySigner,
         parent_id: AccountId,
         new_account_id: &'b str,
@@ -384,7 +381,7 @@ where
             .await?;
 
         let signer = InMemorySigner::from_secret_key(id.clone(), sk);
-        let account = Account::new(id, signer);
+        let account = Account::new(id, signer, self.worker.clone());
 
         Ok(CallExecution {
             result: account,

--- a/workspaces/src/prelude.rs
+++ b/workspaces/src/prelude.rs
@@ -1,3 +1,3 @@
 //! All traits that are essential to the ease of use of workspaces.
 
-pub use crate::network::{DevAccountDeployer, TopLevelAccountCreator};
+pub use crate::network::DevAccountDeployer;

--- a/workspaces/src/prelude.rs
+++ b/workspaces/src/prelude.rs
@@ -1,3 +1,3 @@
 //! All traits that are essential to the ease of use of workspaces.
 
-pub use crate::network::DevAccountDeployer;
+pub use crate::network::TopLevelAccountCreator;

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -148,7 +148,7 @@ impl Worker<Sandbox> {
         id: &AccountId,
         worker: &'a Worker<impl Network>,
     ) -> ImportContractTransaction<'a> {
-        ImportContractTransaction::new(id.to_owned(), &worker.client(), self.clone().coerce())
+        ImportContractTransaction::new(id.to_owned(), worker.client(), self.clone().coerce())
     }
 
     /// Patch state into the sandbox network, given a key and value. This will allow us to set
@@ -176,9 +176,5 @@ impl Worker<Sandbox> {
     /// The port being used by RPC
     pub fn rpc_port(&self) -> u16 {
         self.workspace.rpc_port()
-    }
-
-    pub(crate) fn root_signer(&self) -> Result<InMemorySigner> {
-        self.workspace.root_signer()
     }
 }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -1,18 +1,17 @@
-use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo, TopLevelAccountCreator};
+use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo};
 use crate::network::{Info, Sandbox};
-use crate::result::{CallExecution, CallExecutionDetails, Result, ViewResultDetails};
+use crate::result::{CallExecutionDetails, Result, ViewResultDetails};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
-use crate::types::{AccountId, Gas, InMemorySigner, SecretKey};
+use crate::types::{AccountId, Gas, InMemorySigner};
 use crate::worker::Worker;
 use crate::{Account, Block, Contract};
 use crate::{AccountDetails, Network};
 
-use async_trait::async_trait;
 use near_primitives::types::Balance;
 use std::collections::HashMap;
 
-impl<T> Clone for Worker<T> {
+impl<T: ?Sized> Clone for Worker<T> {
     fn clone(&self) -> Self {
         Self {
             workspace: self.workspace.clone(),
@@ -21,25 +20,6 @@ impl<T> Clone for Worker<T> {
 }
 
 impl<T> AllowDevAccountCreation for Worker<T> where T: AllowDevAccountCreation {}
-
-#[async_trait]
-impl<T> TopLevelAccountCreator for Worker<T>
-where
-    T: TopLevelAccountCreator + Send + Sync,
-{
-    async fn create_tla(&self, id: AccountId, sk: SecretKey) -> Result<CallExecution<Account>> {
-        self.workspace.create_tla(id, sk).await
-    }
-
-    async fn create_tla_and_deploy(
-        &self,
-        id: AccountId,
-        sk: SecretKey,
-        wasm: &[u8],
-    ) -> Result<CallExecution<Contract>> {
-        self.workspace.create_tla_and_deploy(id, sk, wasm).await
-    }
-}
 
 impl<T> NetworkInfo for Worker<T>
 where
@@ -50,7 +30,7 @@ where
     }
 }
 
-impl<T> Worker<T>
+impl<T: ?Sized> Worker<T>
 where
     T: NetworkClient,
 {
@@ -157,18 +137,18 @@ impl Worker<Sandbox> {
     pub fn root_account(&self) -> Result<Account> {
         let account_id = self.info().root_id.clone();
         let signer = self.workspace.root_signer()?;
-        Ok(Account::new(account_id, signer))
+        Ok(Account::new(account_id, signer, self.clone().coerce()))
     }
 
     /// Import a contract from the the given network, and return us a [`ImportContractTransaction`]
     /// which allows to specify further details, such as being able to import contract data and
     /// how far back in time we wanna grab the contract.
-    pub fn import_contract<'a, 'b>(
-        &'b self,
+    pub fn import_contract<'a>(
+        &self,
         id: &AccountId,
         worker: &'a Worker<impl Network>,
-    ) -> ImportContractTransaction<'a, 'b> {
-        self.workspace.import_contract(id, worker)
+    ) -> ImportContractTransaction<'a> {
+        ImportContractTransaction::new(id.to_owned(), &worker.client(), self.clone().coerce())
     }
 
     /// Patch state into the sandbox network, given a key and value. This will allow us to set
@@ -196,5 +176,9 @@ impl Worker<Sandbox> {
     /// The port being used by RPC
     pub fn rpc_port(&self) -> u16 {
         self.workspace.rpc_port()
+    }
+
+    pub(crate) fn root_signer(&self) -> Result<InMemorySigner> {
+        self.workspace.root_signer()
     }
 }

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -3,17 +3,15 @@ mod impls;
 use std::fmt;
 use std::sync::Arc;
 
-use crate::network::{Betanet, Mainnet, Sandbox, Testnet, TopLevelAccountCreator};
-use crate::result::CallExecution;
-use crate::types::{AccountId, SecretKey};
-use crate::{Account, Contract, DevNetwork, Network, Result};
+use crate::network::{Betanet, Mainnet, Sandbox, Testnet};
+use crate::{Network, Result};
 
 /// The `Worker` type allows us to interact with any NEAR related networks, such
 /// as mainnet and testnet. This controls where the environment the worker is
 /// running on top of is. Refer to this for all network related actions such as
 /// deploying a contract, or interacting with transactions.
 pub struct Worker<T: ?Sized> {
-    workspace: Arc<T>,
+    pub(crate) workspace: Arc<T>,
 }
 
 impl<T> Worker<T>
@@ -32,28 +30,6 @@ impl<T: Network + 'static> Worker<T> {
         Worker {
             workspace: self.workspace,
         }
-    }
-}
-
-impl<T> Worker<T>
-where
-    T: DevNetwork + TopLevelAccountCreator + 'static,
-{
-    pub async fn create_tla(&self, id: AccountId, sk: SecretKey) -> Result<CallExecution<Account>> {
-        self.workspace
-            .create_tla(self.clone().coerce(), id, sk)
-            .await
-    }
-
-    pub async fn create_tla_and_deploy(
-        &self,
-        id: AccountId,
-        sk: SecretKey,
-        wasm: &[u8],
-    ) -> Result<CallExecution<Contract>> {
-        self.workspace
-            .create_tla_and_deploy(self.clone().coerce(), id, sk, wasm)
-            .await
     }
 }
 

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -11,8 +11,16 @@ use crate::Network;
 /// as mainnet and testnet. This controls where the environment the worker is
 /// running on top of is. Refer to this for all network related actions such as
 /// deploying a contract, or interacting with transactions.
-pub struct Worker<T> {
+pub struct Worker<T: ?Sized> {
     workspace: Arc<T>,
+}
+
+impl<T: Network + 'static> Worker<T> {
+    pub(crate) fn coerce(self) -> Worker<dyn Network> {
+        Worker {
+            workspace: self.workspace,
+        }
+    }
 }
 
 impl<T> Worker<T>

--- a/workspaces/tests/batch_tx.rs
+++ b/workspaces/tests/batch_tx.rs
@@ -1,7 +1,6 @@
 use serde_json::json;
 use test_log::test;
 use workspaces::operations::Function;
-use workspaces::prelude::*;
 
 #[test(tokio::test)]
 async fn test_batch_tx() -> anyhow::Result<()> {

--- a/workspaces/tests/batch_tx.rs
+++ b/workspaces/tests/batch_tx.rs
@@ -13,7 +13,7 @@ async fn test_batch_tx() -> anyhow::Result<()> {
     // Batch transaction with two `call`s into `set_status`. The second one
     // should override the first one.
     contract
-        .batch(&worker)
+        .batch()
         .call(
             Function::new("set_status")
                 .args_json(json!({
@@ -28,7 +28,7 @@ async fn test_batch_tx() -> anyhow::Result<()> {
         .await?;
 
     let status_msg: String = contract
-        .call(&worker, "get_status")
+        .call("get_status")
         .args_json(serde_json::json!({
             "account_id": contract.id(),
         }))

--- a/workspaces/tests/create_account.rs
+++ b/workspaces/tests/create_account.rs
@@ -8,7 +8,7 @@ async fn test_subaccount_creation() -> anyhow::Result<()> {
     let account = worker.dev_create_account().await?;
 
     let sub = account
-        .create_subaccount(&worker, "subaccount")
+        .create_subaccount("subaccount")
         .transact()
         .await?
         .into_result()?;

--- a/workspaces/tests/create_account.rs
+++ b/workspaces/tests/create_account.rs
@@ -1,6 +1,5 @@
 #![recursion_limit = "256"]
 use test_log::test;
-use workspaces::prelude::*;
 
 #[test(tokio::test)]
 async fn test_subaccount_creation() -> anyhow::Result<()> {

--- a/workspaces/tests/cross_contract.rs
+++ b/workspaces/tests/cross_contract.rs
@@ -2,7 +2,7 @@ use near_sdk::json_types::U128;
 use near_units::parse_near;
 use workspaces::prelude::*;
 use workspaces::result::CallExecutionDetails;
-use workspaces::{AccountId, Contract, Network, Worker};
+use workspaces::{AccountId, Contract};
 
 /// The factory contract used in these tests can be found in
 /// [near-sdk/examples/factory-contract](https://github.com/near/near-sdk-rs/tree/master/examples/factory-contract/high-level).

--- a/workspaces/tests/cross_contract.rs
+++ b/workspaces/tests/cross_contract.rs
@@ -17,7 +17,7 @@ async fn cross_contract_create_contract(
     contract: &Contract,
 ) -> anyhow::Result<CallExecutionDetails> {
     contract
-        .call(worker, "deploy_status_message")
+        .call("deploy_status_message")
         .args_json((status_id.clone(), status_amt))
         .deposit(parse_near!("50 N"))
         .max_gas()
@@ -70,7 +70,7 @@ async fn test_cross_contract_calls() -> anyhow::Result<()> {
 
     let message = "hello world";
     let result = contract
-        .call(&worker, "complex_call")
+        .call("complex_call")
         .args_json((status_id, message))
         .max_gas()
         .transact()

--- a/workspaces/tests/cross_contract.rs
+++ b/workspaces/tests/cross_contract.rs
@@ -13,7 +13,6 @@ const FACTORY_CONTRACT: &[u8] =
 async fn cross_contract_create_contract(
     status_id: &AccountId,
     status_amt: &U128,
-    worker: &Worker<impl Network>,
     contract: &Contract,
 ) -> anyhow::Result<CallExecutionDetails> {
     contract
@@ -35,8 +34,7 @@ async fn test_cross_contract_create_contract() -> anyhow::Result<()> {
     // Expect to fail for trying to create a new contract account with too short of a
     // top level account name, such as purely just "status"
     let status_id: AccountId = "status".parse().unwrap();
-    let outcome =
-        cross_contract_create_contract(&status_id, &status_amt, &worker, &contract).await?;
+    let outcome = cross_contract_create_contract(&status_id, &status_amt, &contract).await?;
     let failures = outcome.failures();
     assert!(
         failures.len() == 1,
@@ -47,8 +45,7 @@ async fn test_cross_contract_create_contract() -> anyhow::Result<()> {
     // Expect to succeed after calling into the contract with expected length for a
     // top level account.
     let status_id: AccountId = "status-top-level-account-long-name".parse().unwrap();
-    let outcome =
-        cross_contract_create_contract(&status_id, &status_amt, &worker, &contract).await?;
+    let outcome = cross_contract_create_contract(&status_id, &status_amt, &contract).await?;
     let failures = outcome.failures();
     assert!(
         failures.is_empty(),
@@ -66,7 +63,7 @@ async fn test_cross_contract_calls() -> anyhow::Result<()> {
     let status_amt = U128::from(parse_near!("35 N"));
 
     let status_id: AccountId = "status-top-level-account-long-name".parse().unwrap();
-    cross_contract_create_contract(&status_id, &status_amt, &worker, &contract).await?;
+    cross_contract_create_contract(&status_id, &status_amt, &contract).await?;
 
     let message = "hello world";
     let result = contract

--- a/workspaces/tests/cross_contract.rs
+++ b/workspaces/tests/cross_contract.rs
@@ -1,6 +1,5 @@
 use near_sdk::json_types::U128;
 use near_units::parse_near;
-use workspaces::prelude::*;
 use workspaces::result::CallExecutionDetails;
 use workspaces::{AccountId, Contract};
 

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -36,17 +36,14 @@ async fn test_dev_deploy() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(&wasm).await?;
 
     let _result = contract
-        .call(&worker, "new_default_meta")
+        .call("new_default_meta")
         .args_json(serde_json::json!({
             "owner_id": contract.id()
         }))
         .transact()
         .await?;
 
-    let actual: NftMetadata = contract
-        .view(&worker, "nft_metadata", Vec::new())
-        .await?
-        .json()?;
+    let actual: NftMetadata = contract.view("nft_metadata", Vec::new()).await?.json()?;
 
     assert_eq!(actual, expected());
 

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -1,7 +1,6 @@
 #![recursion_limit = "256"]
 use serde::{Deserialize, Serialize};
 use test_log::test;
-use workspaces::prelude::*;
 
 const NFT_WASM_FILEPATH: &str = "../examples/res/non_fungible_token.wasm";
 const EXPECTED_NFT_METADATA: &str = r#"{

--- a/workspaces/tests/deploy_project.rs
+++ b/workspaces/tests/deploy_project.rs
@@ -10,14 +10,14 @@ async fn test_dev_deploy_project() -> anyhow::Result<()> {
     let contract = worker.dev_deploy(&wasm).await?;
 
     let _res = contract
-        .call(&worker, "set_status")
+        .call("set_status")
         .args_json(("foo",))
         .max_gas()
         .transact()
         .await?;
 
     let res = contract
-        .call(&worker, "get_status")
+        .call("get_status")
         .args_json((contract.id(),))
         .view()
         .await?;

--- a/workspaces/tests/deploy_project.rs
+++ b/workspaces/tests/deploy_project.rs
@@ -1,7 +1,6 @@
 #![cfg(feature = "unstable")]
 #![recursion_limit = "256"]
 use test_log::test;
-use workspaces::prelude::*;
 
 #[test(tokio::test)]
 async fn test_dev_deploy_project() -> anyhow::Result<()> {
@@ -9,7 +8,7 @@ async fn test_dev_deploy_project() -> anyhow::Result<()> {
     let wasm = workspaces::compile_project("./tests/test-contracts/status-message").await?;
     let contract = worker.dev_deploy(&wasm).await?;
 
-    let _res = contract
+    contract
         .call("set_status")
         .args_json(("foo",))
         .max_gas()

--- a/workspaces/tests/optional_args.rs
+++ b/workspaces/tests/optional_args.rs
@@ -1,7 +1,6 @@
 #![recursion_limit = "256"]
 use near_units::parse_near;
 use test_log::test;
-use workspaces::prelude::*;
 use workspaces::{Contract, DevNetwork, Worker};
 
 async fn init(worker: &Worker<impl DevNetwork>) -> anyhow::Result<Contract> {

--- a/workspaces/tests/optional_args.rs
+++ b/workspaces/tests/optional_args.rs
@@ -10,7 +10,7 @@ async fn init(worker: &Worker<impl DevNetwork>) -> anyhow::Result<Contract> {
         .await?;
 
     contract
-        .call(worker, "new_default_meta")
+        .call("new_default_meta")
         .args_json(serde_json::json!({
             "owner_id": contract.id(),
             "total_supply": parse_near!("1,000,000,000 N").to_string(),
@@ -27,7 +27,7 @@ async fn test_empty_args_error() -> anyhow::Result<()> {
     let contract = init(&worker).await?;
 
     let res = contract
-        .call(&worker, "storage_unregister")
+        .call("storage_unregister")
         .max_gas()
         .deposit(1)
         .transact()
@@ -43,7 +43,7 @@ async fn test_optional_args_present() -> anyhow::Result<()> {
     let contract = init(&worker).await?;
 
     let res = contract
-        .call(&worker, "storage_unregister")
+        .call("storage_unregister")
         .args_json(serde_json::json!({
             "force": true
         }))

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -4,7 +4,6 @@
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use serde_json::json;
 use test_log::test;
-use workspaces::prelude::*;
 use workspaces::{AccountId, DevNetwork, Worker};
 
 const STATUS_MSG_WASM_FILEPATH: &str = "../examples/res/status_message.wasm";

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -34,7 +34,7 @@ async fn view_status_state(
         .transact()
         .await?;
 
-    let mut state_items = contract.view_state(&worker, None).await?;
+    let mut state_items = contract.view_state(None).await?;
     let state = state_items
         .remove(b"STATE".as_slice())
         .ok_or_else(|| anyhow::anyhow!("Could not retrieve STATE"))?;

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -27,7 +27,7 @@ async fn view_status_state(
     let contract = worker.dev_deploy(&wasm).await.unwrap();
 
     contract
-        .call(&worker, "set_status")
+        .call("set_status")
         .args_json(json!({
                 "message": "hello",
         }))


### PR DESCRIPTION
Also, no longer require importing `prelude`