### PR TITLE
chore: Added convenience functions `Account::{from_secret_key, set_secret_key}`

### DIFF
--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -220,16 +220,16 @@ impl Contract {
         &self.account.id
     }
 
-    /// Casts the current [`Contract`] into an [`Account`] type. This does
-    /// nothing on chain/network, and is merely allowing `Account::*` functions
-    /// to be used from this `Contract`.
+    /// Treat this [`Contract`] object as an [`Account`] type. This does nothing
+    /// on chain/network, and is merely allowing `Account::*` functions to be
+    /// used from this `Contract`.
     pub fn as_account(&self) -> &Account {
         &self.account
     }
 
-    /// Casts the current [`Contract`] into an [`Account`] type. This does
-    /// nothing on chain/network, and is merely allowing `Account::*` functions
-    /// to be used from this `Contract`.
+    /// Treat this [`Contract`] object as an [`Account`] type. This does nothing
+    /// on chain/network, and is merely allowing `Account::*` functions to be
+    /// used from this `Contract`.
     pub fn as_account_mut(&mut self) -> &mut Account {
         &mut self.account
     }

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -40,13 +40,13 @@ impl Account {
 
     /// Create an [`Account`] object from an [`AccountId`] and [`SecretKey`].
     pub fn from_secret_key(
-        id: &AccountId,
-        sk: &SecretKey,
+        id: AccountId,
+        sk: SecretKey,
         worker: &Worker<impl Network + 'static>,
     ) -> Self {
         Self {
             id: id.clone(),
-            signer: InMemorySigner::from_secret_key(id.clone(), sk.clone()),
+            signer: InMemorySigner::from_secret_key(id, sk),
             worker: worker.clone().coerce(),
         }
     }
@@ -172,8 +172,8 @@ impl Account {
 
     /// Sets the [`SecretKey`] of this account. Future transactions will be signed
     /// using this newly provided key.
-    pub fn set_secret_key(&mut self, sk: &SecretKey) {
-        self.signer.secret_key = sk.clone();
+    pub fn set_secret_key(&mut self, sk: SecretKey) {
+        self.signer.secret_key = sk;
     }
 }
 
@@ -198,8 +198,8 @@ impl fmt::Debug for Contract {
 impl Contract {
     /// Create a [`Contract`] object from an [`AccountId`] and [`SecretKey`].
     pub fn from_secret_key(
-        id: &AccountId,
-        sk: &SecretKey,
+        id: AccountId,
+        sk: SecretKey,
         worker: &Worker<impl Network + 'static>,
     ) -> Self {
         Self::account(Account::from_secret_key(id, sk, worker))

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -172,7 +172,7 @@ impl Account {
 
     /// Sets the [`SecretKey`] of this account. Future transactions will be signed
     /// using this newly provided key.
-    pub fn set_signer_key(&mut self, sk: &SecretKey) {
+    pub fn set_secret_key(&mut self, sk: &SecretKey) {
         self.signer.secret_key = sk.clone();
     }
 }

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -196,6 +196,7 @@ impl fmt::Debug for Contract {
 }
 
 impl Contract {
+    /// Create a [`Contract`] object from an [`AccountId`] and [`SecretKey`].
     pub fn from_secret_key(
         id: &AccountId,
         sk: &SecretKey,

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -38,6 +38,19 @@ impl Account {
         Ok(Self::new(id, signer, worker.clone().coerce()))
     }
 
+    /// Create an [`Account`] object from an [`AccountId`] and [`SecretKey`].
+    pub fn from_secret_key(
+        id: &AccountId,
+        sk: &SecretKey,
+        worker: &Worker<impl Network + 'static>,
+    ) -> Self {
+        Self {
+            id: id.clone(),
+            signer: InMemorySigner::from_secret_key(id.clone(), sk.clone()),
+            worker: worker.clone().coerce(),
+        }
+    }
+
     pub(crate) fn new(id: AccountId, signer: InMemorySigner, worker: Worker<dyn Network>) -> Self {
         Self { id, signer, worker }
     }
@@ -156,6 +169,12 @@ impl Account {
     pub fn secret_key(&self) -> &SecretKey {
         &self.signer.secret_key
     }
+
+    /// Sets the [`SecretKey`] of this account. Future transactions will be signed
+    /// using this newly provided key.
+    pub fn set_signer_key(&mut self, sk: &SecretKey) {
+        self.signer.secret_key = sk.clone();
+    }
 }
 
 // TODO: allow users to create Contracts so that they can call into
@@ -177,6 +196,14 @@ impl fmt::Debug for Contract {
 }
 
 impl Contract {
+    pub fn from_secret_key(
+        id: &AccountId,
+        sk: &SecretKey,
+        worker: &Worker<impl Network + 'static>,
+    ) -> Self {
+        Self::account(Account::from_secret_key(id, sk, worker))
+    }
+
     pub(crate) fn new(id: AccountId, signer: InMemorySigner, worker: Worker<dyn Network>) -> Self {
         Self {
             account: Account::new(id, signer, worker),
@@ -197,6 +224,13 @@ impl Contract {
     /// to be used from this `Contract`.
     pub fn as_account(&self) -> &Account {
         &self.account
+    }
+
+    /// Casts the current [`Contract`] into an [`Account`] type. This does
+    /// nothing on chain/network, and is merely allowing `Account::*` functions
+    /// to be used from this `Contract`.
+    pub fn as_account_mut(&mut self) -> &mut Account {
+        &mut self.account
     }
 
     pub(crate) fn signer(&self) -> &InMemorySigner {


### PR DESCRIPTION
These seemed pretty useful to add since `Account::from_file` didn't make sense if you already had the `SecretKey` value in memory. `Account::set_secret_key` is useful for changing the signer of transactions to use a different one if users had multiple secret keys