### PR TITLE
fix: Rewording docs to be more intuitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Then later on, we can view our minted NFT's metadata via our `view` call into `n
 
 ### Updating Contract Afterwards
 
-Note that if our contract code changes, `workspaces-rs` does nothing about it since we are utilizing `deploy`/`dev_deploy` to merely send the contract bytes to the network. So if it does change, we will have to recompile the contract as usual, and point `deploy`/`dev_deploy` again to the right WASM files. Refer to the experimental/unstable [`compile_project`](#compiling-contracts-during-test-time) function for telling workspaces to compile a *Rust* project for us.
+Note that if our contract code changes, `workspaces-rs` does nothing about it since we are utilizing `deploy`/`dev_deploy` to merely send the contract bytes to the network. So if it does change, we will have to recompile the contract as usual, and point `deploy`/`dev_deploy` again to the right WASM files. However, there is a workspaces feature that will recompile contract changes for us: refer to the experimental/unstable [`compile_project`](#compiling-contracts-during-test-time) function for telling workspaces to compile a *Rust* project for us.
 
 ## Examples
 More standalone examples can be found in `examples/src/*.rs`.

--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ async fn test_some_function_that_involves_a_transfer() -> anyhow::Result<()> {
 
     let alice = worker.dev_create_account().await?;
     let bob = worker.dev_create_account().await?;
-    let bob_original_balance = bob.view_account(&worker).await?.balance;
+    let bob_original_balance = bob.view_account().await?.balance;
 
     alice.call(contract.id(), "function_that_transfers")
-        .args_json(json!({ "destination_account": &bob.id() }))
+        .args_json(json!({ "destination_account": bob.id() }))
         .max_gas()
         .deposit(transfer_amount)
         .transact()
         .await?;
     assert_eq!(
-        bob.view_account(&worker).await?.balance,
+        bob.view_account().await?.balance,
         bob_original_balance + transfer_amount
     );
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Where
 Then we'll go directly into making a call into the contract, and initialize the NFT contract's metadata:
 ```rust
     let outcome = contract
-        .call(&worker, "new_default_meta")
+        .call("new_default_meta")
         .args_json(json!({
             "owner_id": contract.id(),
         }))
@@ -79,7 +79,7 @@ Afterwards, let's mint an NFT via `nft_mint`. This showcases some extra argument
 ```rust
     let deposit = 10000000000000000000000;
     let outcome = contract
-        .call(&worker, "nft_mint")
+        .call("nft_mint")
         .args_json(json!({
             "token_id": "0",
             "token_owner_id": contract.id(),
@@ -100,7 +100,7 @@ Afterwards, let's mint an NFT via `nft_mint`. This showcases some extra argument
 Then later on, we can view our minted NFT's metadata via our `view` call into `nft_metadata`:
 ```rust
     let result: serde_json::Value = contract
-        .call(&worker, "nft_metadata")
+        .call("nft_metadata")
         .view()
         .await?
         .json()?;
@@ -240,7 +240,7 @@ Following that we will have to init the contract again with our own metadata. Th
         .await?;
 
     owner
-        .call(&worker, contract.id(), "init_method_name")
+        .call(contract.id(), "init_method_name")
         .args_json(serde_json::json!({
             "arg1": value1,
             "arg2": value2,
@@ -265,7 +265,7 @@ async fn test_contract() -> anyhow::Result<()> {
     worker.fast_forward(blocks_to_advance);
 
     // Now, "do_something_with_time" will be in the future and can act on future time-related state.
-    contract.call(&worker, "do_something_with_time")
+    contract.call("do_something_with_time")
         .transact()
         .await?;
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ use near_units::parse_near;
 use serde_json::json;
 ```
 
-We will need to have our pre-compiled WASM contract ahead of time and know its path. In this showcase, we will be pointing to the example's NFT contract:
+We will need to have our pre-compiled WASM contract ahead of time and know its path. Refer to the respective near-sdk-{rs, js} repos/language for where these paths are located.
+
+In this showcase, we will be pointing to the example's NFT contract:
 ```rust
 const NFT_WASM_FILEPATH: &str = "./examples/res/non_fungible_token.wasm";
 ```
@@ -59,6 +61,8 @@ Where
 * `anyhow` - A crate that deals with error handling, making it more robust for developers.
 * `worker` - Our gateway towards interacting with our sandbox environment.
 * `contract`- The deployed contract on sandbox the developer interacts with.
+
+### Initialize Contract & Test Output
 
 Then we'll go directly into making a call into the contract, and initialize the NFT contract's metadata:
 ```rust
@@ -110,6 +114,10 @@ Then later on, we can view our minted NFT's metadata via our `view` call into `n
     Ok(())
 }
 ```
+
+### Updating Contract Afterwards
+
+Note that if our contract code changes, `workspaces-rs` does nothing about it since we are utilizing `deploy`/`dev_deploy` to merely send the contract bytes to the network. So if it does change, we will have to recompile the contract as usual, and point `deploy`/`dev_deploy` again to the right WASM files. Refer to the experimental/unstable [`compile_project`](#compiling-contracts-during-test-time) function for telling workspaces to compile a *Rust* project for us.
 
 ## Common Usage
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Then we'll go directly into making a call into the contract, and initialize the 
         .args_json(json!({
             "owner_id": contract.id(),
         }))
-        .transact()
+        .transact()  // note: we use the contract's keys here to sign the transaction
         .await?;
 
     // outcome contains data like logs, receipts and transaction outcomes.
@@ -174,13 +174,13 @@ async fn main() -> anyhow::Result<()> {
 
 ### Helper Functions
 
-Need to make a helper function regardless of whatever Network?
+Need to make a helper functions utilizing contracts? Just import it and pass it around:
 
 ```rust
-use workspaces::{Contract, DevNetwork, Network, Worker};
+use workspaces::Contract;
 
 // Helper function that calls into a contract we give it
-async fn call_my_func(worker: Worker<impl Network>, contract: &Contract) -> anyhow::Result<()> {
+async fn call_my_func(contract: &Contract) -> anyhow::Result<()> {
     // Call into the function `contract_function` with args:
     contract.call("contract_function")
         .args_json(serde_json::json!({
@@ -190,11 +190,18 @@ async fn call_my_func(worker: Worker<impl Network>, contract: &Contract) -> anyh
         .await?;
     Ok(())
 }
+```
+
+Or to pass around workers regardless of networks:
+```rust
+use workspaces::{DevNetwork, Worker};
+
+const CONTRACT_BYTES: &[u8] = include_bytes!("./relative/path/to/file.wasm");
 
 // Create a helper function that deploys a specific contract
-// NOTE: `dev_deploy` is only available on `DevNetwork`s such sandbox and testnet.
+// NOTE: `dev_deploy` is only available on `DevNetwork`s such as sandbox and testnet.
 async fn deploy_my_contract(worker: Worker<impl DevNetwork>) -> anyhow::Result<Contract> {
-    worker.dev_deploy(&std::fs::read(CONTRACT_FILE)?).await
+    worker.dev_deploy(CONTRACT_BYTES).await
 }
 ```
 

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -97,6 +97,11 @@ impl<'a> Function<'a> {
 /// A builder-like object that will allow specifying various actions to be performed
 /// in a single transaction. For details on each of the actions, find them in
 /// [NEAR transactions](https://docs.near.org/docs/concepts/transaction).
+///
+/// All actions are performed on the account specified by `receiver_id`. This object
+/// is most commonly constructed from [`Account::batch`] or [`Contract::batch`],
+/// where `receiver_id` is specified in the `Account::batch` while `Contract::id()`
+/// is used by default for `Contract::batch`.
 pub struct Transaction<'a> {
     client: &'a Client,
     signer: InMemorySigner,

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -66,7 +66,8 @@ impl Account {
 
     /// Call a contract on the network specified within `worker`, and return
     /// a [`CallTransaction`] object that we will make use to populate the
-    /// rest of the call details.
+    /// rest of the call details. Note that the current [`Account`]'s secret
+    /// key is used as the signer of the transaction.
     pub fn call<'a, 'b>(
         &'a self,
         contract_id: &AccountId,
@@ -177,8 +178,6 @@ impl Account {
     }
 }
 
-// TODO: allow users to create Contracts so that they can call into
-// them without deploying the contract themselves.
 /// `Contract` is directly associated to a contract in the network provided by the
 /// [`Worker`] that creates it. This type offers methods to interact with any
 /// network, such as creating transactions and calling into contract functions.
@@ -239,12 +238,11 @@ impl Contract {
     }
 
     /// Call the current contract's function using the contract's own account
-    /// details to do the signing. Returns a [`CallTransaction`] object that
+    /// secret key to do the signing. Returns a [`CallTransaction`] object that
     /// we will make use to populate the rest of the call details.
     ///
-    /// If we want to make use of the contract's account to call into a
-    /// different contract besides the current one, use
-    /// `contract.as_account().call` instead.
+    /// If we want to make use of the contract's secret key as a signer to call
+    /// into another contract, use `contract.as_account().call` instead.
     pub fn call<'a>(&self, function: &'a str) -> CallTransaction<'_, 'a> {
         self.account.call(self.id(), function)
     }
@@ -276,8 +274,8 @@ impl Contract {
         self.account.delete_account(beneficiary_id).await
     }
 
-    /// Start a batch transaction, using the current contract as the signer and
-    /// making calls into this contract. Returns a [`Transaction`] object that
+    /// Start a batch transaction, using the current contract's secret key as the
+    /// signer, making calls into itself. Returns a [`Transaction`] object that
     /// we can use to add Actions to the batched transaction. Call `transact`
     /// to send the batched transaction to the network.
     pub fn batch(&self) -> Transaction {


### PR DESCRIPTION
Updating docs:
- better wording for `Transaction`. 
- added the note from https://github.com/near/workspaces-rs/pull/176 to be more precise about recompilation.
- more explicit details about who the signer is when making a call, which should alleviate: https://github.com/near/workspaces-rs/issues/172
- rearranged the README to be more in flow