### PR TITLE
feat: Added API Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- RPC API Keys used to interact with services such as Pagoda Console.
+
 ## [0.5.0]
 ### Added
 - Error handling with opaque `workspaces::error::Error` type: https://github.com/near/workspaces-rs/pull/149

--- a/README.md
+++ b/README.md
@@ -312,3 +312,4 @@ For a full example, take a look at [workspaces/tests/deploy_project.rs](https://
 These environment variables will be useful if there was ever a snag hit:
 - `NEAR_RPC_TIMEOUT_SECS`: The default is 10 seconds, but this is the amount of time beforing timing out waiting for a RPC service when talking to the sandbox or any other network such as testnet.
 - `NEAR_SANDBOX_BIN_PATH`: Set this to our own prebuilt `neard-sandbox` bin path if we want to use a non-default version of the sandbox or configure nearcore with our own custom features that we want to test in workspaces.
+- `NEAR_RPC_API_KEY`: This is the API key necessary for communicating with RPC nodes. This is useful when interacting with services such as Pagoda Console or a service that can access RPC metrics.

--- a/workspaces/src/network/betanet.rs
+++ b/workspaces/src/network/betanet.rs
@@ -22,7 +22,7 @@ pub struct Betanet {
 
 impl Betanet {
     pub(crate) async fn new() -> crate::result::Result<Self> {
-        let client = Client::new(RPC_URL);
+        let client = Client::new(RPC_URL)?;
         client.wait_for_rpc().await?;
 
         Ok(Self {

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -23,7 +23,7 @@ pub struct Mainnet {
 
 impl Mainnet {
     pub(crate) async fn new() -> Result<Self> {
-        let client = Client::new(RPC_URL);
+        let client = Client::new(RPC_URL)?;
         client.wait_for_rpc().await?;
 
         Ok(Self {
@@ -38,7 +38,7 @@ impl Mainnet {
     }
 
     pub(crate) async fn archival() -> Result<Self> {
-        let client = Client::new(ARCHIVAL_URL);
+        let client = Client::new(ARCHIVAL_URL)?;
         client.wait_for_rpc().await?;
 
         Ok(Self {

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -48,7 +48,7 @@ impl Sandbox {
     pub(crate) async fn new() -> Result<Self> {
         let mut server = SandboxServer::default();
         server.start()?;
-        let client = Client::new(&server.rpc_addr());
+        let client = Client::new(&server.rpc_addr())?;
         client.wait_for_rpc().await?;
 
         let info = Info {

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -31,7 +31,7 @@ pub struct Testnet {
 
 impl Testnet {
     pub(crate) async fn new() -> Result<Self> {
-        let client = Client::new(RPC_URL);
+        let client = Client::new(RPC_URL)?;
         client.wait_for_rpc().await?;
 
         Ok(Self {
@@ -46,7 +46,7 @@ impl Testnet {
     }
 
     pub(crate) async fn archival() -> Result<Self> {
-        let client = Client::new(ARCHIVAL_URL);
+        let client = Client::new(ARCHIVAL_URL)?;
         client.wait_for_rpc().await?;
 
         Ok(Self {

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -46,15 +46,20 @@ pub struct Client {
 }
 
 impl Client {
-    pub(crate) fn new(rpc_addr: &str) -> Self {
+    pub(crate) fn new(rpc_addr: &str) -> Result<Self> {
         let connector = JsonRpcClient::new_client();
-        let rpc_client = connector.connect(rpc_addr);
+        let mut rpc_client = connector.connect(rpc_addr);
+        if let Ok(api_key) = std::env::var("NEAR_RPC_API_KEY") {
+            let api_key = near_jsonrpc_client::auth::ApiKey::new(api_key)
+                .map_err(|e| ErrorKind::DataConversion.custom(e))?;
+            rpc_client = rpc_client.header(api_key);
+        }
 
-        Self {
+        Ok(Self {
             rpc_client,
             rpc_addr: rpc_addr.into(),
             access_key_nonces: RwLock::new(HashMap::new()),
-        }
+        })
     }
 
     pub(crate) async fn query_broadcast_tx(


### PR DESCRIPTION
PR adds in `NEAR_RPC_API_KEY` to interact with RPC related services. Resolves https://github.com/near/workspaces-rs/issues/184