### PR TITLE
feat: Contract from Account

### DIFF
--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -30,7 +30,7 @@ impl fmt::Debug for Account {
 impl Account {
     /// Create a new account with the given path to the credentials JSON file
     pub fn from_file(
-        path: impl AsRef<std::path::Path>,
+        path: impl AsRef<Path>,
         worker: &Worker<impl Network + 'static>,
     ) -> Result<Self> {
         let signer = InMemorySigner::from_file(path.as_ref())?;
@@ -280,6 +280,12 @@ impl Contract {
     /// to send the batched transaction to the network.
     pub fn batch(&self) -> Transaction {
         self.account.batch(self.id())
+    }
+}
+
+impl From<Account> for Contract {
+    fn from(account: Account) -> Self {
+        Self { account }
     }
 }
 


### PR DESCRIPTION
All this change does is simply allow for a `Contract` to be created from an `Account`.

This is beneficial for our needs as we would like to create root contracts in the sand box. I do not believe that this should cause any negative issues and simply opens up more creation abilities of `Contract`.

## Example

```
async fn make_evm_account() -> anyhow::Result<(Contract)> {
    let worker = workspaces::sandbox().await?;
    let root: NearAccount = worker.root_account()?.into();
    
    let sk = SecretKey::from_random(KeyType::ED25519);
    let aurora_account: Contract = root
        .create_subaccount("aurora.root")
        .initial_balance(100_000_000_000_000_000_000_000_000)
        .keys(sk)
        .transact()
        .await?
        .into_results()?
        .into();
    Ok(aurora_account)
}
```