### PR TITLE
chore: add unstable feature to docs build

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -55,3 +55,6 @@ tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 default = ["install"]
 install = []  # Install the sandbox binary during compile time
 unstable = ["cargo_metadata", "async-process"]
+
+[package.metadata.docs.rs]
+features = ["unstable"]


### PR DESCRIPTION
Wanted to link to `compile_project` today and noticed it wasn't being added to rust docs.