### PR TITLE
feat: return `ExecutionFailure` error

### DIFF
--- a/workspaces/src/error/mod.rs
+++ b/workspaces/src/error/mod.rs
@@ -4,6 +4,7 @@
 pub(crate) mod execution;
 mod impls;
 
+pub use near_primitives::errors::TxExecutionError;
 use std::borrow::Cow;
 
 use crate::result::ExecutionFailure;

--- a/workspaces/src/result.rs
+++ b/workspaces/src/result.rs
@@ -315,6 +315,13 @@ impl ExecutionSuccess {
     }
 }
 
+impl ExecutionFailure {
+    /// Returns the execution error as a [`near_primitives::errors::TxExecutionError`].
+    pub fn error(&self) -> &TxExecutionError {
+        &self.value
+    }
+}
+
 impl<T> ExecutionResult<T> {
     /// Returns just the transaction outcome.
     pub fn outcome(&self) -> &ExecutionOutcome {


### PR DESCRIPTION
Right now, there is no way to be able to return the error, which will be useful for users. The best way to do this is to simply provide all the details that a transaction could fail through the `near_primitives::TxExecutionError`.