### PR TITLE
chore: Make compile_project use latest error API

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -12,7 +12,6 @@ Library for automating workflows and testing NEAR smart contracts.
 [dependencies]
 async-trait = "0.1"
 async-process = { version = "1.3", optional = true }
-anyhow = "1.0"
 base64 = "0.13"
 borsh = "0.9"
 cargo_metadata = { version = "0.14.2", optional = true }
@@ -44,6 +43,7 @@ near-sandbox-utils = "0.5.0"
 libc = "0.2"
 
 [dev-dependencies]
+anyhow = "1.0"
 borsh = "0.9"
 futures = "0.3"
 near-units = "0.2.0"

--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -1,12 +1,16 @@
-use anyhow::anyhow;
 use async_process::Command;
-use cargo_metadata::{Message, Metadata, MetadataCommand};
+use cargo_metadata::{Error as MetadataError, Message, Metadata, MetadataCommand};
+use tracing::debug;
+
 use std::env;
 use std::fmt::Debug;
 use std::fs;
+use std::io;
 use std::path::Path;
 use std::process::Stdio;
-use tracing::debug;
+
+use crate::error::ErrorKind;
+use crate::Result;
 
 fn cargo_bin() -> Command {
     match env::var_os("CARGO") {
@@ -17,13 +21,19 @@ fn cargo_bin() -> Command {
 
 /// Fetch current project's metadata (i.e. project invoking this method, not the one that we are
 /// trying to compile).
-fn root_cargo_metadata() -> anyhow::Result<Metadata> {
-    MetadataCommand::new().exec().map_err(Into::into)
+fn root_cargo_metadata() -> Result<Metadata> {
+    MetadataCommand::new().exec().map_err(|e| match e {
+        // comes from cargo metadata command error message, so IO should be appropriate
+        MetadataError::CargoMetadata { stderr } => ErrorKind::Io.message(stderr),
+        MetadataError::Io(err) => ErrorKind::Io.custom(err),
+        MetadataError::Utf8(err) => ErrorKind::DataConversion.custom(err),
+        MetadataError::ErrUtf8(err) => ErrorKind::DataConversion.custom(err),
+        MetadataError::Json(err) => ErrorKind::DataConversion.custom(err),
+        err @ MetadataError::NoJson => ErrorKind::DataConversion.message(err.to_string()),
+    })
 }
 
-async fn build_cargo_project<P: AsRef<Path> + Debug>(
-    project_path: P,
-) -> anyhow::Result<Vec<Message>> {
+async fn build_cargo_project<P: AsRef<Path> + Debug>(project_path: P) -> Result<Vec<Message>> {
     let metadata = root_cargo_metadata()?;
     let output = cargo_bin()
         .args([
@@ -39,26 +49,29 @@ async fn build_cargo_project<P: AsRef<Path> + Debug>(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .output()
-        .await?;
+        .await
+        .map_err(|e| ErrorKind::Io.custom(e))?;
+
     debug!(
         target: "workspaces",
         "Building project '{:?}' resulted in status {:?}",
         &project_path, output.status
     );
+
     if output.status.success() {
         let reader = std::io::BufReader::new(output.stdout.as_slice());
         Ok(Message::parse_stream(reader).map(|m| m.unwrap()).collect())
     } else {
-        Err(anyhow!(
+        Err(ErrorKind::Io.message(format!(
             "Failed to build project '{:?}'.\n\
             Stderr:\n\
             {}\n\
             Stdout:\n\
             {}",
             project_path,
-            String::from_utf8(output.stderr)?,
-            String::from_utf8(output.stdout)?,
-        ))
+            String::from_utf8(output.stderr).map_err(|e| ErrorKind::DataConversion.custom(e))?,
+            String::from_utf8(output.stdout).map_err(|e| ErrorKind::DataConversion.custom(e))?,
+        )))
     }
 }
 
@@ -66,8 +79,16 @@ async fn build_cargo_project<P: AsRef<Path> + Debug>(
 ///
 /// NOTE: This function does not check whether the resulting wasm file is a valid smart
 /// contract or not.
-pub async fn compile_project(project_path: &str) -> anyhow::Result<Vec<u8>> {
-    let messages = build_cargo_project(fs::canonicalize(project_path)?).await?;
+pub async fn compile_project(project_path: &str) -> Result<Vec<u8>> {
+    let project_path = fs::canonicalize(project_path).map_err(|e| match e.kind() {
+        io::ErrorKind::NotFound => ErrorKind::Io.message(format!(
+            "Incorrect file supplied to compile_project('{}')",
+            project_path
+        )),
+        _ => ErrorKind::Io.custom(e),
+    })?;
+    let messages = build_cargo_project(project_path).await?;
+
     // We find the last compiler artifact message which should contain information about the
     // resulting .wasm file
     let compile_artifact = messages
@@ -77,9 +98,9 @@ pub async fn compile_project(project_path: &str) -> anyhow::Result<Vec<u8>> {
             _ => None,
         })
         .last()
-        .ok_or(anyhow!(
+        .ok_or_else(|| ErrorKind::Io.message(
             "Cargo failed to produce any compilation artifacts. \
-                 Please check that your project contains a NEAR smart contract."
+                 Please check that your project contains a NEAR smart contract.",
         ))?;
     // The project could have generated many auxiliary files, we are only interested in .wasm files
     let wasm_files = compile_artifact
@@ -88,14 +109,19 @@ pub async fn compile_project(project_path: &str) -> anyhow::Result<Vec<u8>> {
         .filter(|f| f.as_str().ends_with(".wasm"))
         .collect::<Vec<_>>();
     match wasm_files.as_slice() {
-        [] => Err(anyhow!(
+        [] => Err(ErrorKind::Io.message(
             "Compilation resulted in no '.wasm' target files. \
-                 Please check that your project contains a NEAR smart contract."
+                 Please check that your project contains a NEAR smart contract.",
         )),
-        [file] => Ok(tokio::fs::read(file.canonicalize()?).await?),
-        _ => Err(anyhow!(
+        [file] => {
+            let file = file.canonicalize().map_err(|e| ErrorKind::Io.custom(e))?;
+            Ok(tokio::fs::read(file)
+                .await
+                .map_err(|e| ErrorKind::Io.custom(e))?)
+        }
+        _ => Err(ErrorKind::Io.message(format!(
             "Compilation resulted in more than one '.wasm' target file: {:?}",
             wasm_files
-        )),
+        ))),
     }
 }

--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -98,10 +98,12 @@ pub async fn compile_project(project_path: &str) -> Result<Vec<u8>> {
             _ => None,
         })
         .last()
-        .ok_or_else(|| ErrorKind::Io.message(
-            "Cargo failed to produce any compilation artifacts. \
+        .ok_or_else(|| {
+            ErrorKind::Io.message(
+                "Cargo failed to produce any compilation artifacts. \
                  Please check that your project contains a NEAR smart contract.",
-        ))?;
+            )
+        })?;
     // The project could have generated many auxiliary files, we are only interested in .wasm files
     let wasm_files = compile_artifact
         .filenames


### PR DESCRIPTION
This updates the error API in `compile_project` to use latest errors. Also resolves https://github.com/near/workspaces-rs/issues/199 by adding a new error message in the case of missing/incorrect filepath