### PR TITLE
fix: child sandbox process becoming orphaned on early process termination

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -11,7 +11,7 @@ Library for automating workflows and testing NEAR smart contracts.
 
 [dependencies]
 async-trait = "0.1"
-async-process = { version = "1.3", optional = true }
+async-process = "1.3"
 base64 = "0.13"
 borsh = "0.9"
 cargo_metadata = { version = "0.14.2", optional = true }
@@ -54,7 +54,7 @@ tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 [features]
 default = ["install"]
 install = []  # Install the sandbox binary during compile time
-unstable = ["cargo_metadata", "async-process"]
+unstable = ["cargo_metadata"]
 
 [package.metadata.docs.rs]
 features = ["unstable"]

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -47,7 +47,7 @@ impl Sandbox {
 
     pub(crate) async fn new() -> Result<Self> {
         let mut server = SandboxServer::default();
-        server.start()?;
+        server.start().await?;
         let client = Client::new(&server.rpc_addr());
         client.wait_for_rpc().await?;
 


### PR DESCRIPTION
This fixes workspaces tests from orphaning the child sandbox process when someone goes to kill the process early, such as the case of a long running test that a user wishes to terminates early because they made changes or whatever reason.

The solution here was to just switch over to the async_process command version which already has this mechanism built-in. They have an external process that kills orphaned processes, and we already needed to switch over to the async version anyways.