### PR TITLE
Chore: Upgrade to version 0.4.0 of near-jsonrpc-client, and version 0.15.0 for nearcore libraries

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 anyhow = "1.0"
 borsh = "0.9"
 maplit = "1.0"
-near-units = "0.1.0"
+near-units = "0.2.0"
 serde = "1.0"
 serde_with = "1"
 # arbitrary_precision enabled for u128 types that workspaces requires for Balance types

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -14,6 +14,7 @@ async-trait = "0.1"
 async-process = "1.3"
 base64 = "0.13"
 borsh = "0.9"
+bs58 = "0.4"
 cargo_metadata = { version = "0.14.2", optional = true }
 chrono = "0.4.19"
 dirs = "3.0.2"
@@ -29,11 +30,11 @@ tokio-retry = "0.3"
 tracing = "0.1"
 url = { version = "2.2.2", features = ["serde"] }
 
-near-account-id = "0.14.0"
-near-crypto = "0.14.0"
-near-primitives = "0.14.0"
-near-jsonrpc-primitives = "0.14.0"
-near-jsonrpc-client = { version = "0.4.0-beta.0", features = ["sandbox"] }
+near-account-id = "0.15.0"
+near-crypto = "0.15.0"
+near-primitives = "0.15.0"
+near-jsonrpc-primitives = "0.15.0"
+near-jsonrpc-client = { version = "0.4.0", features = ["sandbox"] }
 near-sandbox-utils = "0.5.0"
 
 [build-dependencies]

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -92,7 +92,7 @@ impl TopLevelAccountCreator for Testnet {
                 // create the account for us in testnet when we used the Helper contract.
                 total_gas_burnt: 0,
 
-                status: near_primitives::views::FinalExecutionStatus::SuccessValue(String::new()),
+                status: near_primitives::views::FinalExecutionStatus::SuccessValue(Vec::new()),
                 details: ExecutionDetails {
                     transaction: ExecutionOutcome {
                         block_hash: CryptoHash::default(),
@@ -101,7 +101,7 @@ impl TopLevelAccountCreator for Testnet {
                         gas_burnt: 0,
                         tokens_burnt: 0,
                         executor_id: "testnet".parse().unwrap(),
-                        status: ExecutionStatusView::SuccessValue(String::new()),
+                        status: ExecutionStatusView::SuccessValue(Vec::new()),
                     },
                     receipts: Vec::new(),
                 },

--- a/workspaces/src/result.rs
+++ b/workspaces/src/result.rs
@@ -198,7 +198,7 @@ impl ExecutionFinalResult {
         match self.status {
             FinalExecutionStatus::SuccessValue(value) => Ok(ExecutionResult {
                 total_gas_burnt: self.total_gas_burnt,
-                value,
+                value: base64::encode(value),
                 details: self.details,
             }),
             FinalExecutionStatus::Failure(tx_error) => Err(ExecutionResult {
@@ -435,7 +435,9 @@ impl ExecutionOutcome {
     /// particular outcome has failed or not.
     pub fn into_result(self) -> Result<ValueOrReceiptId> {
         match self.status {
-            ExecutionStatusView::SuccessValue(value) => Ok(ValueOrReceiptId::Value(value)),
+            ExecutionStatusView::SuccessValue(value) => {
+                Ok(ValueOrReceiptId::Value(base64::encode(value)))
+            }
             ExecutionStatusView::SuccessReceiptId(hash) => {
                 Ok(ValueOrReceiptId::ReceiptId(CryptoHash(hash.0)))
             }

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -206,7 +206,7 @@ impl Client {
             .map_err(|e| RpcErrorCode::QueryFailure.custom(e))?;
 
         match query_resp.kind {
-            QueryResponseKind::ViewState(state) => Ok(tool::into_state_map(&state.values)?),
+            QueryResponseKind::ViewState(state) => Ok(tool::into_state_map(state.values)),
             _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
         }
     }

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -199,6 +199,7 @@ impl Client {
                 request: QueryRequest::ViewState {
                     account_id: contract_id,
                     prefix: StoreKey::from(prefix.map(Vec::from).unwrap_or_default()),
+                    include_proof: false,
                 },
             })
             .await

--- a/workspaces/src/rpc/tool.rs
+++ b/workspaces/src/rpc/tool.rs
@@ -11,21 +11,14 @@ use url::Url;
 use near_crypto::SecretKey;
 use near_primitives::views::StateItem;
 
-use crate::error::{Error, ErrorKind, RpcErrorCode};
+use crate::error::{ErrorKind, RpcErrorCode};
 use crate::result::Result;
 use crate::types::{AccountId, PublicKey};
 
 /// Convert `StateItem`s over to a Map<data_key, value_bytes> representation.
 /// Assumes key and value are base64 encoded, so this also decodes them.
-pub(crate) fn into_state_map(state_items: &[StateItem]) -> Result<HashMap<Vec<u8>, Vec<u8>>> {
-    let decode = |s: &StateItem| {
-        Ok((
-            base64::decode(&s.key).map_err(|e| Error::custom(ErrorKind::DataConversion, e))?,
-            base64::decode(&s.value).map_err(|e| Error::custom(ErrorKind::DataConversion, e))?,
-        ))
-    };
-
-    state_items.iter().map(decode).collect()
+pub(crate) fn into_state_map(state_items: Vec<StateItem>) -> HashMap<Vec<u8>, Vec<u8>> {
+    state_items.into_iter().map(|s| (s.key, s.value)).collect()
 }
 
 pub(crate) fn random_account_id() -> AccountId {

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 pub use near_account_id::AccountId;
 use near_primitives::logging::pretty_hash;
-use near_primitives::serialize::{from_base, to_base};
+use near_primitives::serialize::to_base58;
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, ErrorKind};
@@ -29,6 +29,10 @@ pub type Balance = u128;
 
 /// Height of a specific block
 pub type BlockHeight = u64;
+
+fn from_base58(s: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
+    bs58::decode(s).into_vec().map_err(|err| err.into())
+}
 
 /// Key types supported for either a [`SecretKey`] or [`PublicKey`]
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -148,7 +152,7 @@ impl std::str::FromStr for CryptoHash {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bytes = from_base(s).map_err(|e| ErrorKind::DataConversion.custom(e))?;
+        let bytes = from_base58(s).map_err(|e| ErrorKind::DataConversion.custom(e))?;
         Self::try_from(bytes)
     }
 }
@@ -188,7 +192,7 @@ impl fmt::Debug for CryptoHash {
 
 impl fmt::Display for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&to_base(&self.0), f)
+        fmt::Display::fmt(&to_base58(&self.0), f)
     }
 }
 

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -20,8 +20,8 @@ fn test_keypair_ed25519() -> anyhow::Result<()> {
 
 #[test]
 fn test_keypair_secp256k1() -> anyhow::Result<()> {
-    let pk_expected = "\"secp256k1:BtJtBjukUQbcipnS78adSwUKE38sdHnk7pTNZH7miGXfodzUunaAcvY43y37nm7AKbcTQycvdgUzFNWsd7dgPZZ\"";
-    let sk_expected = "\"secp256k1:9ZNzLxNff6ohoFFGkbfMBAFpZgD7EPoWeiuTpPAeeMRV\"";
+    let pk_expected = "\"secp256k1:5ftgm7wYK5gtVqq1kxMGy7gSudkrfYCbpsjL6sH1nwx2oj5NR2JktohjzB6fbEhhRERQpiwJcpwnQjxtoX3GS3cQ\"";
+    let sk_expected = "\"secp256k1:X4ETFKtQkSGVoZEnkn7bZ3LyajJaK2b3eweXaKmynGx\"";
 
     let sk = SecretKey::from_seed(KeyType::SECP256K1, "test");
     let pk = sk.public_key();


### PR DESCRIPTION
`near-jsonrpc-client` was officially released, so we do not need to depend on the `-beta.0` version any more.

This upgrade is important because cargo thinks that `0.4.0-beta.0` should be compatible with `0.4.0`, however they are not due to the different versions of the nearcore libraries. This means that `workspaces` fails to compile as a dependency of other crates (unless the `near-jsonrpc-client` version is fixed to the `beta` one in `Cargo.lock`).

Along with the upgrade, there were a few minor API changes in the nearcore libraries which meant we needed to make a few extra changes here (namely around encoding values as base64 / base 58).