### PR TITLE
feat: Add async builders for `view_*` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,27 @@
 
 ## [Unreleased]
 
-## [0.5.0]
 ### Added
+
+- `view_*` builders have been added
+
+### Changed
+
+- `{Account, Contract, Worker}::view_state` moved `prefix` parameter into builder. i.e.
+
+```
+worker.view_state("account_id", Some(prefix)).await?;
+// is now
+worker.view_state("account_id")
+    .prefix(prefix)
+    .await?;
+// if prefix was `None`, then simply delete the None argument.
+```
+
+## [0.5.0]
+
+### Added
+
 - Error handling with opaque `workspaces::error::Error` type: https://github.com/near/workspaces-rs/pull/149
 - Require `#[must_use]` on the Execution value returned by `transact()`: https://github.com/near/workspaces-rs/pull/150
   - Added `ExecutionFinalResult`, `ExecutionResult`, `ExecutionSuccess` and `ExecutionFailure` types
@@ -11,8 +30,9 @@
   - Added `unwrap()` to not care about Err variant in `ExecutionResult`s
 
 ### Changed
-- Renamed CallExecution* types: https://github.com/near/workspaces-rs/pull/150
-  - Renamed `CallExecution`` to `Execution`
+
+- Renamed CallExecution\* types: https://github.com/near/workspaces-rs/pull/150
+  - Renamed ` CallExecution`` to  `Execution`
   - Renamed `CallExecutionDetails` to `ExecutionFinalResult`
 - `args_json` and `args_borsh` no longer return `Result`s and are deferred till later when `transact()`ed: https://github.com/near/workspaces-rs/pull/149
 - API changes from removing `worker` parameter from function calls: https://github.com/near/workspaces-rs/pull/181
@@ -20,54 +40,65 @@
   - `workspaces::prelude::*` import no longer necessary, where we no longer able to import `workspaces::prelude::DevAccountDeployer` directly.
 
 ### Removed
+
 - Removed impls from exection result: https://github.com/near/workspaces-rs/pull/150
   - Removed `impl<T> From<CallExecution<T>> for Result<T>`
   - Removed `impl From<FinalExecutionOutcomeView> for CallExecutionDetails`
 - No longer require `worker` to be passed in for each transaction: https://github.com/near/workspaces-rs/pull/181
 
 ### Fixed
+
 - Gas estimation issue resolved with latest sandbox node (Aug 29, 2022): https://github.com/near/workspaces-rs/pull/188
 - Fixed parallel tests, where calling into the same contract would require waiting on a previous call: https://github.com/near/workspaces-rs/pull/173
 
 ## [0.4.1] - 2022-08-16
 
 ### Added
+
 - Derive `Eq` on `AccountDetails` type: https://github.com/near/workspaces-rs/pull/177/files
 
 ### Fixed
+
 - Fix macOS non-deterministic overflow error when starting up sandbox: https://github.com/near/workspaces-rs/pull/179
 
 ## [0.4.0] - 2022-07-20
 
 ### Added
+
 - Mac M1 Support: https://github.com/near/workspaces-rs/pull/169
 - Added `Account::secret_key` to grab the account's secret key: https://github.com/near/workspaces-rs/pull/144
 - `Debug`/`Clone` impls for `Account`/`Contract`, and `Debug` for `Worker`: https://github.com/near/workspaces-rs/pull/167
 - `ExecutionOutcome::tokens_burnt` is now available: https://github.com/near/workspaces-rs/pull/168
 
 ### Fixed
+
 - internally no longer creating a new RPC client per call: https://github.com/near/workspaces-rs/pull/154
 - upped near dependencies to fix transitive vulnerabilities: https://github.com/near/workspaces-rs/pull/169
 
 ### Changed
+
 - Default sandbox version is now using commit hash master/13a66dda709a4148f6395636914dca2a55df1390 (July 18, 2022): https://github.com/near/workspaces-rs/pull/169
 
 ## [0.3.1] - 2022-06-20
 
 ### Added
+
 - Raw bytes API similar to `json`/`borsh` calls: https://github.com/near/workspaces-rs/pull/133/files
 - Expose `types` module and added `SecretKey` creation: https://github.com/near/workspaces-rs/pull/139
 
 ### Fixed
+
 - If sandbox gets started multiple times, short circuit it early on: https://github.com/near/workspaces-rs/pull/135
 - Fix short timeouts on connecting to RPC for macos with custom env variable to specify timeout if needed: https://github.com/near/workspaces-rs/pull/143
 
 ## [0.3.0] - 2022-05-10
 
 ### Added
+
 - Added betanet support https://github.com/near/workspaces-rs/pull/116
 
 ### Changed
+
 - Updated default sandbox version to `97c0410de519ecaca369aaee26f0ca5eb9e7de06` commit of nearcore to include 1.26 protocol changes https://github.com/near/workspaces-rs/pull/134
 
 - Exposed `CallExecutionDetails::raw_bytes` API: https://github.com/near/workspaces-rs/pull/133
@@ -75,14 +106,17 @@
 ## [0.2.1] - 2022-04-12
 
 ### Added
+
 - Added more docs to top level or exposed types/functions: https://github.com/near/workspaces-rs/pull/115
 
 ### Fixed
+
 - Fix `docs.rs` builds failing on sandbox install: https://github.com/near/workspaces-rs/pull/115
 
 ## [0.2.0] - 2022-04-05
 
 ### Added
+
 - Time-traveling - the ability to go forwards in block height within tests. This allows to test time specific data changing within contracts: https://github.com/near/workspaces-rs/pull/73
 - Credentials created from account/contract creation are now allowed to be stored and specified by users. https://github.com/near/workspaces-rs/pull/98
 - [Unstable] Allow users to compile contract projects within tests without having to manually go through this step. https://github.com/near/workspaces-rs/pull/77
@@ -95,8 +129,8 @@
 - Convenient `CallExecutionDetails::{is_success, is_failure}` for testing outcomes of transactions. https://github.com/near/workspaces-rs/pull/58
 - Added `mainnet_archival` and `testnet_archival`, where `ref-finance` example now uses `mainnet_archival`. https://github.com/near/workspaces-rs/pull/57 and https://github.com/near/workspaces-rs/pull/94
 
-
 ### Changed
+
 - key type for `patch_state` now a slice and no longer require `StoreKey`. https://github.com/near/workspaces-rs/pull/109
 - Reorganized imports internally for better maintainability. https://github.com/near/workspaces-rs/pull/102
 - No longer running into non-deterministic query failures if RPC isn't available, but this is a breaking API. All `workspaces::{sandbox, testnet, mainnet}` now require `.await?` at the end. https://github.com/near/workspaces-rs/pull/99
@@ -108,15 +142,16 @@
 - Functions no longer take in owned but referenced `AccountId`s now. https://github.com/near/workspaces-rs/pull/52
 
 ### Removed
+
 - Empty JSON array is no longer a valid default argument supplied to transactions. Recommended to supply empty `{}` in the case of JSON if all function arguments in the contract are optional types. https://github.com/near/workspaces-rs/pull/84
 
 ## [0.1.1] - 2021-01-24
 
 ### Changed
+
 - Fix race condition when installing sandbox and running multiples tests at the same time. https://github.com/near/workspaces-rs/pull/46
 
-
-[Unreleased]: https://github.com/near/workspaces-rs/compare/0.5.0...HEAD
+[unreleased]: https://github.com/near/workspaces-rs/compare/0.5.0...HEAD
 [0.5.0]: https://github.com/near/workspaces-rs/compare/0.4.1...0.5.0
 [0.4.1]: https://github.com/near/workspaces-rs/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/near/workspaces-rs/compare/0.3.1...0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 - Apart of the changes from adding `view_*` async builders, we can have a couple breaking changes to the `view_*` functions:
   - `{Account, Contract, Worker}::view_state` moved `prefix` parameter into builder. i.e.
-  - {}
+  - `view` function changed to be a builder, and no longer take in `args` as a parameter. It instead has been moved to the builder side.
+  - Changed `Worker::view_latest_block` to `Worker::view_block` as the default behavior is equivalent.
 
 ```
 worker.view_state("account_id", Some(prefix)).await?;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- [Apart of the changes from adding `view_*` async builders, we can have a couple breaking changes to the `view_*` functions](https://github.com/near/workspaces-rs/pull/218):
+- [Apart of the changes from adding `view_*` async builders, we have a couple breaking changes to the `view_*` functions](https://github.com/near/workspaces-rs/pull/218):
   - `{Account, Contract, Worker}::view_state` moved `prefix` parameter into builder. i.e.
     ```
     worker.view_state("account_id", Some(prefix)).await?;
@@ -20,6 +20,7 @@
     ```
   - `view` function changed to be a builder, and no longer take in `args` as a parameter. It instead has been moved to the builder side.
   - Changed `Worker::view_latest_block` to `Worker::view_block` as the default behavior is equivalent.
+  - `operations::Function` type no longer takes a lifetime parameter.
 
 ## [0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - `view` function changed to be a builder, and no longer take in `args` as a parameter. It instead has been moved to the builder side.
   - Changed `Worker::view_latest_block` to `Worker::view_block` as the default behavior is equivalent.
   - `operations::Function` type no longer takes a lifetime parameter.
+  - `operations::CallTransaction` type takes one less lifetime parameter.
 
 ## [0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Added
 
-- `view_*` builders have been added
+- `view_*` asynchronous builders have been added which provides being able to query from a specific [`BlockReference`]()
 
 ### Changed
 
-- `{Account, Contract, Worker}::view_state` moved `prefix` parameter into builder. i.e.
+- Apart of the changes from adding `view_*` async builders, we can have a couple breaking changes to the `view_*` functions:
+  - `{Account, Contract, Worker}::view_state` moved `prefix` parameter into builder. i.e.
+  - {}
 
 ```
 worker.view_state("account_id", Some(prefix)).await?;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,23 @@
 
 ### Added
 
-- `view_*` asynchronous builders have been added which provides being able to query from a specific [`BlockReference`]()
+- [`view_*` asynchronous builders have been added which provides being able to query from a specific block hash or block height](https://github.com/near/workspaces-rs/pull/218)
 
 ### Changed
 
-- Apart of the changes from adding `view_*` async builders, we can have a couple breaking changes to the `view_*` functions:
+- [Apart of the changes from adding `view_*` async builders, we can have a couple breaking changes to the `view_*` functions](https://github.com/near/workspaces-rs/pull/218):
   - `{Account, Contract, Worker}::view_state` moved `prefix` parameter into builder. i.e.
+    ```
+    worker.view_state("account_id", Some(prefix)).await?;
+    // is now
+    worker.view_state("account_id")
+        .prefix(prefix)
+        .await?;
+    // if prefix was `None`, then simply delete the None argument.
+    ```
   - `view` function changed to be a builder, and no longer take in `args` as a parameter. It instead has been moved to the builder side.
   - Changed `Worker::view_latest_block` to `Worker::view_block` as the default behavior is equivalent.
 
-```
-worker.view_state("account_id", Some(prefix)).await?;
-// is now
-worker.view_state("account_id")
-    .prefix(prefix)
-    .await?;
-// if prefix was `None`, then simply delete the None argument.
-```
 ## [0.6.0]
 
 ### Added
@@ -174,12 +174,8 @@ worker.view_state("account_id")
 
 - Fix race condition when installing sandbox and running multiples tests at the same time. https://github.com/near/workspaces-rs/pull/46
 
-<<<<<<< HEAD
-[unreleased]: https://github.com/near/workspaces-rs/compare/0.5.0...HEAD
-=======
 [unreleased]: https://github.com/near/workspaces-rs/compare/0.6.0...HEAD
 [0.6.0]: https://github.com/near/workspaces-rs/compare/0.5.0...0.6.0
->>>>>>> 3d9a76a593470643342d7acb8f2903e941d901b1
 [0.5.0]: https://github.com/near/workspaces-rs/compare/0.4.1...0.5.0
 [0.4.1]: https://github.com/near/workspaces-rs/compare/0.4.0...0.4.1
 [0.4.0]: https://github.com/near/workspaces-rs/compare/0.3.1...0.4.0

--- a/examples/src/fast_forward.rs
+++ b/examples/src/fast_forward.rs
@@ -18,7 +18,7 @@ async fn main() -> anyhow::Result<()> {
         contract.call("current_env_data").view().await?.json()?;
     println!("timestamp = {}, epoch_height = {}", timestamp, epoch_height);
 
-    let block_info = worker.view_latest_block().await?;
+    let block_info = worker.view_block().await?;
     println!("BlockInfo pre-fast_forward {:?}", block_info);
 
     // Call into fast_forward. This will take a bit of time to invoke, but is
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
         contract.call("current_env_data").view().await?.json()?;
     println!("timestamp = {}, epoch_height = {}", timestamp, epoch_height);
 
-    let block_info = worker.view_latest_block().await?;
+    let block_info = worker.view_block().await?;
     println!("BlockInfo post-fast_forward {:?}", block_info);
 
     Ok(())

--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -38,12 +38,10 @@ async fn main() -> anyhow::Result<()> {
 
     let result: serde_json::Value = worker
         .view(contract.id(), "nft_metadata")
-        .args(Vec::new())
         .await?
         .json()?;
 
     println!("--------------\n{}", result);
-
     println!("Dev Account ID: {}", contract.id());
 
     Ok(())

--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -36,10 +36,7 @@ async fn main() -> anyhow::Result<()> {
 
     println!("nft_mint outcome: {:#?}", outcome);
 
-    let result: serde_json::Value = worker
-        .view(contract.id(), "nft_metadata")
-        .await?
-        .json()?;
+    let result: serde_json::Value = worker.view(contract.id(), "nft_metadata").await?.json()?;
 
     println!("--------------\n{}", result);
     println!("Dev Account ID: {}", contract.id());

--- a/examples/src/nft.rs
+++ b/examples/src/nft.rs
@@ -37,7 +37,8 @@ async fn main() -> anyhow::Result<()> {
     println!("nft_mint outcome: {:#?}", outcome);
 
     let result: serde_json::Value = worker
-        .view(contract.id(), "nft_metadata", Vec::new())
+        .view(contract.id(), "nft_metadata")
+        .args(Vec::new())
         .await?
         .json()?;
 

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 
 use near_units::{parse_gas, parse_near};
+use serde_json::json;
 use workspaces::network::Sandbox;
 use workspaces::{Account, AccountId, Contract, Worker};
 use workspaces::{BlockHeight, DevNetwork};
@@ -36,7 +37,7 @@ async fn create_ref(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Result
 
     owner
         .call(ref_finance.id(), "new")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "owner_id": ref_finance.id(),
             "exchange_fee": 4,
             "referral_fee": 1,
@@ -47,7 +48,7 @@ async fn create_ref(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Result
 
     owner
         .call(ref_finance.id(), "storage_deposit")
-        .args_json(serde_json::json!({}))
+        .args_json(json!({}))
         .deposit(parse_near!("30 mN"))
         .transact()
         .await?
@@ -68,7 +69,7 @@ async fn create_wnear(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Resu
 
     owner
         .call(wnear.id(), "new")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "owner_id": owner.id(),
             "total_supply": parse_near!("1,000,000,000 N"),
         }))
@@ -78,7 +79,7 @@ async fn create_wnear(owner: &Account, worker: &Worker<Sandbox>) -> anyhow::Resu
 
     owner
         .call(wnear.id(), "storage_deposit")
-        .args_json(serde_json::json!({}))
+        .args_json(json!({}))
         .deposit(parse_near!("0.008 N"))
         .transact()
         .await?
@@ -109,14 +110,14 @@ async fn create_pool_with_liquidity(
 
     ref_finance
         .call("extend_whitelisted_tokens")
-        .args_json(serde_json::json!({ "tokens": token_ids }))
+        .args_json(json!({ "tokens": token_ids }))
         .transact()
         .await?
         .into_result()?;
 
     let pool_id: u64 = ref_finance
         .call("add_simple_pool")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "tokens": token_ids,
             "fee": 25
         }))
@@ -127,7 +128,7 @@ async fn create_pool_with_liquidity(
 
     owner
         .call(ref_finance.id(), "register_tokens")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "token_ids": token_ids,
         }))
         .deposit(1)
@@ -139,7 +140,7 @@ async fn create_pool_with_liquidity(
 
     owner
         .call(ref_finance.id(), "add_liquidity")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "pool_id": pool_id,
             "amounts": token_amounts,
         }))
@@ -161,7 +162,7 @@ async fn deposit_tokens(
         ref_finance
             .as_account()
             .call(contract_id, "storage_deposit")
-            .args_json(serde_json::json!({
+            .args_json(json!({
                 "registration_only": true,
             }))
             .deposit(parse_near!("1 N"))
@@ -171,7 +172,7 @@ async fn deposit_tokens(
 
         owner
             .call(contract_id, "ft_transfer_call")
-            .args_json(serde_json::json!({
+            .args_json(json!({
                 "receiver_id": ref_finance.id(),
                 "amount": amount.to_string(),
                 "msg": "",
@@ -198,7 +199,7 @@ async fn create_custom_ft(
     // Initialize our FT contract with owner metadata and total supply available
     // to be traded and transfered into other contracts such as Ref-Finance
     ft.call("new_default_meta")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "owner_id": owner.id(),
             "total_supply": parse_near!("1,000,000,000 N").to_string(),
         }))
@@ -259,7 +260,7 @@ async fn main() -> anyhow::Result<()> {
 
     let ft_deposit: String = worker
         .view(ref_finance.id(), "get_deposit")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "account_id": owner.id(),
             "token_id": ft.id(),
         }))
@@ -270,7 +271,7 @@ async fn main() -> anyhow::Result<()> {
 
     let wnear_deposit: String = worker
         .view(ref_finance.id(), "get_deposit")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "account_id": owner.id(),
             "token_id": wnear.id(),
         }))
@@ -286,7 +287,7 @@ async fn main() -> anyhow::Result<()> {
 
     let expected_return: String = worker
         .view(ref_finance.id(), "get_return")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "pool_id": pool_id,
             "token_in": ft.id(),
             "token_out": wnear.id(),
@@ -303,8 +304,8 @@ async fn main() -> anyhow::Result<()> {
 
     let actual_out = owner
         .call(ref_finance.id(), "swap")
-        .args_json(serde_json::json!({
-            "actions": vec![serde_json::json!({
+        .args_json(json!({
+            "actions": vec![json!({
                 "pool_id": pool_id,
                 "token_in": ft.id(),
                 "token_out": wnear.id(),
@@ -331,7 +332,7 @@ async fn main() -> anyhow::Result<()> {
 
     let ft_deposit: String = worker
         .view(ref_finance.id(), "get_deposit")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "account_id": owner.id(),
             "token_id": ft.id(),
         }))
@@ -342,7 +343,7 @@ async fn main() -> anyhow::Result<()> {
 
     let wnear_deposit: String = ref_finance
         .view("get_deposit")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "account_id": owner.id(),
             "token_id": wnear.id(),
         }))

--- a/examples/src/ref_finance.rs
+++ b/examples/src/ref_finance.rs
@@ -258,32 +258,22 @@ async fn main() -> anyhow::Result<()> {
     ///////////////////////////////////////////////////////////////////////////
 
     let ft_deposit: String = worker
-        .view(
-            ref_finance.id(),
-            "get_deposit",
-            serde_json::json!({
-                "account_id": owner.id(),
-                "token_id": ft.id(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view(ref_finance.id(), "get_deposit")
+        .args_json(serde_json::json!({
+            "account_id": owner.id(),
+            "token_id": ft.id(),
+        }))
         .await?
         .json()?;
     println!("Current FT deposit: {}", ft_deposit);
     assert_eq!(ft_deposit, parse_near!("100 N").to_string());
 
     let wnear_deposit: String = worker
-        .view(
-            ref_finance.id(),
-            "get_deposit",
-            serde_json::json!({
-                "account_id": owner.id(),
-                "token_id": wnear.id(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view(ref_finance.id(), "get_deposit")
+        .args_json(serde_json::json!({
+            "account_id": owner.id(),
+            "token_id": wnear.id(),
+        }))
         .await?
         .json()?;
 
@@ -295,18 +285,13 @@ async fn main() -> anyhow::Result<()> {
     ///////////////////////////////////////////////////////////////////////////
 
     let expected_return: String = worker
-        .view(
-            ref_finance.id(),
-            "get_return",
-            serde_json::json!({
-                "pool_id": pool_id,
-                "token_in": ft.id(),
-                "token_out": wnear.id(),
-                "amount_in": parse_near!("1 N").to_string(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view(ref_finance.id(), "get_return")
+        .args_json(serde_json::json!({
+            "pool_id": pool_id,
+            "token_in": ft.id(),
+            "token_out": wnear.id(),
+            "amount_in": parse_near!("1 N").to_string(),
+        }))
         .await?
         .json()?;
 
@@ -345,31 +330,22 @@ async fn main() -> anyhow::Result<()> {
     ///////////////////////////////////////////////////////////////////////////
 
     let ft_deposit: String = worker
-        .view(
-            ref_finance.id(),
-            "get_deposit",
-            serde_json::json!({
-                "account_id": owner.id(),
-                "token_id": ft.id(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view(ref_finance.id(), "get_deposit")
+        .args_json(serde_json::json!({
+            "account_id": owner.id(),
+            "token_id": ft.id(),
+        }))
         .await?
         .json()?;
     println!("New FT deposit after swap: {}", ft_deposit);
     assert_eq!(ft_deposit, parse_near!("99 N").to_string());
 
     let wnear_deposit: String = ref_finance
-        .view(
-            "get_deposit",
-            serde_json::json!({
-                "account_id": owner.id(),
-                "token_id": wnear.id(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view("get_deposit")
+        .args_json(serde_json::json!({
+            "account_id": owner.id(),
+            "token_id": wnear.id(),
+        }))
         .await?
         .json()?;
     println!("New WNear deposit after swap: {}", wnear_deposit);

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -1,5 +1,7 @@
-use borsh::{self, BorshDeserialize, BorshSerialize};
 use std::env;
+
+use borsh::{self, BorshDeserialize, BorshSerialize};
+use serde_json::json;
 use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
 use tracing_subscriber::EnvFilter;
@@ -51,7 +53,7 @@ async fn deploy_status_contract(
     // This will `call` into `set_status` with the message we want to set.
     contract
         .call("set_status")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "message": msg,
         }))
         .transact()
@@ -107,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
     // Now grab the state to see that it has indeed been patched:
     let status: String = sandbox_contract
         .view("get_status")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "account_id": testnet_contract_id,
         }))
         .await?
@@ -119,7 +121,7 @@ async fn main() -> anyhow::Result<()> {
     // See that sandbox state was overriden. Grabbing get_status(sandbox_contract_id) should yield Null
     let result: Option<String> = sandbox_contract
         .view("get_status")
-        .args_json(serde_json::json!({
+        .args_json(json!({
             "account_id": sandbox_contract.id(),
         }))
         .await?

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -106,14 +106,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Now grab the state to see that it has indeed been patched:
     let status: String = sandbox_contract
-        .view(
-            "get_status",
-            serde_json::json!({
-                "account_id": testnet_contract_id,
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view("get_status")
+        .args_json(serde_json::json!({
+            "account_id": testnet_contract_id,
+        }))
         .await?
         .json()?;
 
@@ -122,14 +118,10 @@ async fn main() -> anyhow::Result<()> {
 
     // See that sandbox state was overriden. Grabbing get_status(sandbox_contract_id) should yield Null
     let result: Option<String> = sandbox_contract
-        .view(
-            "get_status",
-            serde_json::json!({
-                "account_id": sandbox_contract.id(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view("get_status")
+        .args_json(serde_json::json!({
+            "account_id": sandbox_contract.id(),
+        }))
         .await?
         .json()?;
     assert_eq!(result, None);

--- a/examples/src/spooning.rs
+++ b/examples/src/spooning.rs
@@ -79,7 +79,7 @@ async fn main() -> anyhow::Result<()> {
             .parse()
             .map_err(anyhow::Error::msg)?;
 
-        let mut state_items = worker.view_state(&contract_id, None).await?;
+        let mut state_items = worker.view_state(&contract_id).await?;
 
         let state = state_items.remove(b"STATE".as_slice()).unwrap();
         let status_msg = StatusMessage::try_from_slice(&state)?;

--- a/examples/src/status_message.rs
+++ b/examples/src/status_message.rs
@@ -18,14 +18,10 @@ async fn main() -> anyhow::Result<()> {
     println!("set_status: {:?}", outcome);
 
     let result: String = contract
-        .view(
-            "get_status",
-            json!({
-                "account_id": contract.id(),
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view("get_status")
+        .args_json(json!({
+            "account_id": contract.id(),
+        }))
         .await?
         .json()?;
 

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -17,6 +17,7 @@ borsh = "0.9"
 cargo_metadata = { version = "0.14.2", optional = true }
 chrono = "0.4.19"
 dirs = "3.0.2"
+futures = "0.3"
 hex = "0.4.2"
 portpicker = "0.1.1"
 rand = "0.8.4"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -18,7 +18,6 @@ bs58 = "0.4"
 cargo_metadata = { version = "0.14.2", optional = true }
 chrono = "0.4.19"
 dirs = "3.0.2"
-futures = "0.3"
 hex = "0.4.2"
 portpicker = "0.1.1"
 rand = "0.8.4"

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -243,7 +243,7 @@ pub struct CallTransaction<'a> {
     function: Function,
 }
 
-impl<'a, 'b> CallTransaction<'a> {
+impl<'a> CallTransaction<'a> {
     pub(crate) fn new(
         worker: &'a Worker<dyn Network>,
         contract_id: AccountId,

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -25,10 +25,10 @@ const MAX_GAS: Gas = 300_000_000_000_000;
 /// the function name, arguments, the amount of gas to use and deposit.
 #[derive(Debug)]
 pub struct Function<'a> {
-    name: &'a str,
-    args: Result<Vec<u8>>,
-    deposit: Balance,
-    gas: Gas,
+    pub(crate) name: &'a str,
+    pub(crate) args: Result<Vec<u8>>,
+    pub(crate) deposit: Balance,
+    pub(crate) gas: Gas,
 }
 
 impl<'a> Function<'a> {

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -24,17 +24,21 @@ const MAX_GAS: Gas = 300_000_000_000_000;
 /// A set of arguments we can provide to a transaction, containing
 /// the function name, arguments, the amount of gas to use and deposit.
 #[derive(Debug)]
-pub struct Function<'a> {
-    pub(crate) name: &'a str,
+pub struct FunctionArgs<T> {
+    pub(crate) name: T,
     pub(crate) args: Result<Vec<u8>>,
     pub(crate) deposit: Balance,
     pub(crate) gas: Gas,
 }
 
-impl<'a> Function<'a> {
+pub type Function<'a> = FunctionArgs<&'a str>;
+/// Owned version of [`Function`], whereby a lifetime is not attached.
+pub type FunctionOwned = FunctionArgs<String>;
+
+impl<T> FunctionArgs<T> {
     /// Initialize a new instance of [`Function`], tied to a specific function on a
     /// contract that lives directly on a contract we've specified in [`Transaction`].
-    pub fn new(name: &'a str) -> Self {
+    pub fn new(name: T) -> Self {
         Self {
             name,
             args: Ok(vec![]),

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -323,12 +323,8 @@ impl<'a, 'b> CallTransaction<'a, 'b> {
     /// Instead of transacting the transaction, call into the specified view function.
     pub async fn view(self) -> Result<ViewResultDetails> {
         self.worker
-            .client()
-            .view(
-                self.contract_id,
-                self.function.name.to_string(),
-                self.function.args?,
-            )
+            .view(&self.contract_id, self.function.name)
+            .args(self.function.args?)
             .await
     }
 }

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -23,7 +23,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::types::{Balance, BlockId, BlockReference, Finality, Gas, StoreKey};
 use near_primitives::views::{
-    AccessKeyView, AccountView, BlockView, ContractCodeView, FinalExecutionOutcomeView,
+    AccessKeyView, BlockView, ContractCodeView, FinalExecutionOutcomeView,
     QueryRequest, StatusResponse,
 };
 
@@ -182,29 +182,6 @@ impl Client {
         match query_resp.kind {
             QueryResponseKind::ViewState(state) => Ok(tool::into_state_map(&state.values)?),
             _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
-        }
-    }
-
-    pub(crate) async fn view_account(
-        &self,
-        account_id: AccountId,
-        block_id: Option<BlockId>,
-    ) -> Result<AccountView> {
-        let block_reference = block_id
-            .map(Into::into)
-            .unwrap_or_else(|| Finality::None.into());
-
-        let query_resp = self
-            .query(&methods::query::RpcQueryRequest {
-                block_reference,
-                request: QueryRequest::ViewAccount { account_id },
-            })
-            .await
-            .map_err(|e| RpcErrorCode::QueryFailure.custom(e))?;
-
-        match query_resp.kind {
-            QueryResponseKind::ViewAccount(account) => Ok(account),
-            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying account")),
         }
     }
 

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -158,56 +158,6 @@ impl Client {
         .await
     }
 
-    pub(crate) async fn view_state(
-        &self,
-        contract_id: AccountId,
-        prefix: Option<&[u8]>,
-        block_id: Option<BlockId>,
-    ) -> Result<HashMap<Vec<u8>, Vec<u8>>> {
-        let block_reference = block_id
-            .map(Into::into)
-            .unwrap_or_else(|| Finality::None.into());
-
-        let query_resp = self
-            .query(&methods::query::RpcQueryRequest {
-                block_reference,
-                request: QueryRequest::ViewState {
-                    account_id: contract_id,
-                    prefix: StoreKey::from(prefix.map(Vec::from).unwrap_or_default()),
-                },
-            })
-            .await
-            .map_err(|e| RpcErrorCode::QueryFailure.custom(e))?;
-
-        match query_resp.kind {
-            QueryResponseKind::ViewState(state) => Ok(tool::into_state_map(&state.values)?),
-            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
-        }
-    }
-
-    pub(crate) async fn view_code(
-        &self,
-        account_id: AccountId,
-        block_id: Option<BlockId>,
-    ) -> Result<ContractCodeView> {
-        let block_reference = block_id
-            .map(Into::into)
-            .unwrap_or_else(|| Finality::None.into());
-
-        let query_resp = self
-            .query(&methods::query::RpcQueryRequest {
-                block_reference,
-                request: QueryRequest::ViewCode { account_id },
-            })
-            .await
-            .map_err(|e| RpcErrorCode::QueryFailure.custom(e))?;
-
-        match query_resp.kind {
-            QueryResponseKind::ViewCode(code) => Ok(code),
-            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying code")),
-        }
-    }
-
     pub(crate) async fn view_block(&self, block_ref: Option<BlockReference>) -> Result<BlockView> {
         let block_reference = block_ref.unwrap_or_else(|| Finality::None.into());
         let block_view = self

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -101,21 +101,21 @@ impl Client {
         .await
     }
 
-    pub(crate) async fn query_nolog<M>(&self, method: &M) -> MethodCallResult<M::Response, M::Error>
+    pub(crate) async fn query_nolog<M>(&self, method: M) -> MethodCallResult<M::Response, M::Error>
     where
         M: methods::RpcMethod,
     {
-        retry(|| async { self.rpc_client.call(method).await }).await
+        retry(|| async { self.rpc_client.call(&method).await }).await
     }
 
-    pub(crate) async fn query<M>(&self, method: &M) -> MethodCallResult<M::Response, M::Error>
+    pub(crate) async fn query<M>(&self, method: M) -> MethodCallResult<M::Response, M::Error>
     where
         M: methods::RpcMethod + Debug,
         M::Response: Debug,
         M::Error: Debug,
     {
         retry(|| async {
-            let result = self.rpc_client.call(method).await;
+            let result = self.rpc_client.call(&method).await;
             tracing::debug!(
                 target: "workspaces",
                 "Querying RPC with {:?} resulted in {:?}",

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -21,15 +21,13 @@ use near_primitives::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeployContractAction,
     FunctionCallAction, SignedTransaction, TransferAction,
 };
-use near_primitives::types::{Balance, BlockId, BlockReference, Finality, Gas, StoreKey};
+use near_primitives::types::{Balance, BlockReference, Finality, Gas};
 use near_primitives::views::{
-    AccessKeyView, BlockView, ContractCodeView, FinalExecutionOutcomeView,
-    QueryRequest, StatusResponse,
+    AccessKeyView, BlockView, FinalExecutionOutcomeView, QueryRequest, StatusResponse,
 };
 
 use crate::error::{Error, ErrorKind, RpcErrorCode};
 use crate::result::Result;
-use crate::rpc::tool;
 use crate::types::{AccountId, InMemorySigner, Nonce, PublicKey};
 
 pub(crate) const DEFAULT_CALL_FN_GAS: Gas = 10_000_000_000_000;

--- a/workspaces/src/rpc/mod.rs
+++ b/workspaces/src/rpc/mod.rs
@@ -3,3 +3,5 @@ pub(crate) mod tool;
 
 pub mod patch;
 pub mod query;
+
+pub type BoxFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;

--- a/workspaces/src/rpc/mod.rs
+++ b/workspaces/src/rpc/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod client;
+pub(crate) mod query;
 pub(crate) mod tool;
 
 pub mod patch;

--- a/workspaces/src/rpc/mod.rs
+++ b/workspaces/src/rpc/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod client;
-pub(crate) mod query;
 pub(crate) mod tool;
 
 pub mod patch;
+pub mod query;

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -102,7 +102,7 @@ impl<'a, 'b> ImportContractTransaction<'a> {
         let mut records = vec![
             StateRecord::Account {
                 account_id: account_id.clone(),
-                account: account_view.clone().into(),
+                account: account_view.clone(),
             },
             StateRecord::AccessKey {
                 account_id: account_id.clone(),

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -1,0 +1,166 @@
+use std::future::{ready, Future, IntoFuture, Ready};
+use std::marker::PhantomData;
+
+use futures::future::AndThen;
+use futures::future::BoxFuture;
+use futures::future::TryFutureExt;
+// use futures::TryFuture;
+
+use near_account_id::AccountId;
+use near_jsonrpc_client::errors::JsonRpcError;
+use near_jsonrpc_client::methods::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse};
+use near_jsonrpc_client::methods::{self, RpcMethod};
+use near_jsonrpc_primitives::types::query::QueryResponseKind;
+use near_primitives::types::{BlockId, BlockReference};
+use near_primitives::views::QueryRequest;
+
+use crate::error::{Error, RpcErrorCode};
+use crate::rpc::client::Client;
+use crate::types::BlockHeight;
+use crate::{AccountDetails, CryptoHash, Result};
+
+pub struct Query<'a, T> {
+    pub(crate) client: &'a Client,
+    pub(crate) request: near_primitives::views::QueryRequest,
+    pub(crate) block_ref: Option<BlockReference>,
+    // pub(crate) method: T,
+    pub(crate) _data: PhantomData<T>,
+}
+
+// impl<'a, T> Query<'a, T> {
+//     fn new(client: &'a Client, )
+// }
+
+impl<'a, T> Query<'a, T> {
+    /// Specify at which block height to import the contract from. This is usable with
+    /// any network this object is importing from, but be aware that only archival
+    /// networks will have the full history while networks like mainnet or testnet
+    /// only has the history from 5 or less epochs ago.
+    pub fn block_height(mut self, height: BlockHeight) -> Self {
+        self.block_ref = Some(BlockId::Height(height).into());
+        self
+    }
+
+    /// Specify at which block hash to import the contract from. This is usable with
+    /// any network this object is importing from, but be aware that only archival
+    /// networks will have the full history while networks like mainnet or testnet
+    /// only has the history from 5 or less epochs ago.
+    pub fn block_hash(mut self, hash: CryptoHash) -> Self {
+        self.block_ref = Some(BlockId::Hash(near_primitives::hash::CryptoHash(hash.0)).into());
+        self
+    }
+}
+
+impl<'a, T, R> IntoFuture for Query<'a, T>
+where
+    T: Queryable<Output = R> + 'static,
+    <T as Queryable>::QueryMethod: RpcMethod + std::fmt::Debug,
+    <<T as Queryable>::QueryMethod as RpcMethod>::Response: std::fmt::Debug,
+    <<T as Queryable>::QueryMethod as RpcMethod>::Error: std::fmt::Debug,
+    // Fut: TryFuture<Error = Error>,
+    // F: FnOnce(QueryResponseKind) -> Fut,
+    // Self: Sized,
+{
+    type Output = Result<R>;
+    // type IntoFuture = Ready<Self::Output>;
+    // type IntoFuture = AndThen<
+    //     impl Future<
+    //         Output = Result<
+    //             <RpcQueryRequest as RpcMethod>::Response,
+    //             JsonRpcError<<RpcQueryRequest as RpcMethod>::Error>,
+    //         >,
+    //     >,
+    //     impl Future<Output = Result<R, JsonRpcError<RpcQueryError>>>,
+    //     FnOnce(RpcQueryResponse) -> impl Future<Output = Result<R, JsonRpcError<RpcQueryError>>>,
+    // >;
+    // type IntoFuture = futures::future::IntoFuture;
+
+    // TODO: boxed future required due to impl Trait as type alias being unstable. So once
+    // https://github.com/rust-lang/rust/issues/63063 is resolved, we can move to that instead.
+    type IntoFuture = BoxFuture<'a, Self::Output>;
+
+    fn into_future(self) -> Self::IntoFuture {
+        let block_reference = self.block_ref.unwrap_or_else(BlockReference::latest);
+        let fut = self
+            .client
+            .query(methods::query::RpcQueryRequest {
+                block_reference,
+                request: self.request,
+            })
+            // .query(self.method.into_query_request(block_ref))
+            .map_ok(T::process_response)
+            .map_err(|e| RpcErrorCode::QueryFailure.custom(e));
+        // .and_then(|result| async move { Ok(T::into_value(result)) });
+
+        Box::pin(fut)
+        // Box::pin(TryFutureExt::into_future(fut))
+    }
+}
+
+pub trait Queryable {
+    // TODO: associated default type is unstable. So for now, will require writing
+    // the manual impls for query_request
+    type QueryMethod: RpcMethod;
+
+    /// Expected output after performing a query. This is mainly to convert over
+    /// the type from near-primitives to a workspace type.
+    type Output;
+
+    fn into_query_request(self, block_ref: BlockReference) -> Self::QueryMethod;
+    // fn process_response(query: <Self::QueryMethod as RpcMethod>::Response) -> Self::Output;
+    fn process_response(query: RpcQueryResponse) -> Self::Output;
+}
+
+struct View;
+pub struct ViewCode {
+    account_id: AccountId,
+}
+pub struct ViewAccount {
+    account_id: AccountId,
+}
+struct ViewBlock;
+struct ViewState;
+struct ViewAccessKey;
+struct ViewAccessKeyList;
+
+impl Queryable for ViewCode {
+    type Output = Result<Vec<u8>>;
+    type QueryMethod = methods::query::RpcQueryRequest;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod {
+            block_reference,
+            request: QueryRequest::ViewCode {
+                account_id: self.account_id,
+            },
+        }
+    }
+
+    fn process_response(query: RpcQueryResponse) -> Self::Output {
+        match query.kind {
+            QueryResponseKind::ViewCode(contract) => Ok(contract.code),
+            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying account")),
+        }
+    }
+}
+
+impl Queryable for ViewAccount {
+    type Output = Result<AccountDetails>;
+    type QueryMethod = methods::query::RpcQueryRequest;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod {
+            block_reference,
+            request: QueryRequest::ViewAccount {
+                account_id: self.account_id,
+            },
+        }
+    }
+
+    fn process_response(query: RpcQueryResponse) -> Self::Output {
+        match query.kind {
+            QueryResponseKind::ViewAccount(account) => Ok(account.into()),
+            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying account")),
+        }
+    }
+}

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -133,8 +133,8 @@ pub struct ViewAccessKey {
     pub(crate) public_key: PublicKey,
 }
 
-pub(crate) struct ViewAccessKeyList {
-    account_id: AccountId,
+pub struct ViewAccessKeyList {
+    pub(crate) account_id: AccountId,
 }
 
 impl Queryable for ViewFunction {

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -17,7 +17,7 @@
 //! But most of the time, we do not need to worry about these types as they are
 //! meant to be transitory, and only exist while calling into their immediate
 //! methods. So the above example should look more like the following:
-//! //! ```ignore
+//! ```ignore
 //! fn my_func(worker: &Worker<impl Network>>) -> anyhow::Result<()> {
 //!     let contract_id: AccountId = "some-contract.near"
 //!     let bytes = worker.view_state(&contract_id).await?;
@@ -36,7 +36,7 @@ use near_primitives::types::{BlockId, BlockReference, StoreKey};
 use near_primitives::views::{BlockView, QueryRequest};
 
 use crate::error::RpcErrorCode;
-use crate::operations::FunctionOwned;
+use crate::operations::Function;
 use crate::result::ViewResultDetails;
 use crate::rpc::client::Client;
 use crate::rpc::{tool, BoxFuture};
@@ -147,7 +147,7 @@ pub trait ProcessQuery {
 
 pub struct ViewFunction {
     pub(crate) account_id: AccountId,
-    pub(crate) function: FunctionOwned,
+    pub(crate) function: Function,
 }
 
 pub struct ViewCode {

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -14,7 +14,7 @@ use crate::error::RpcErrorCode;
 use crate::operations::FunctionOwned;
 use crate::result::ViewResultDetails;
 use crate::rpc::client::Client;
-use crate::types::{AccessKey, AccessKeyInfo, BlockHeight, PublicKey};
+use crate::types::{AccessKey, AccessKeyInfo, BlockHeight, PublicKey, Finality};
 use crate::{AccountDetails, Block, CryptoHash, Result};
 
 use super::tool;
@@ -34,8 +34,7 @@ impl<'a, T> Query<'a, T> {
         }
     }
 
-    /// Specify at which block height to import the contract from. This is usable with
-    /// any network this object is importing from, but be aware that only archival
+    /// Specify at which block height to query from. Note that only archival
     /// networks will have the full history while networks like mainnet or testnet
     /// only has the history from 5 or less epochs ago.
     pub fn block_height(mut self, height: BlockHeight) -> Self {
@@ -43,12 +42,17 @@ impl<'a, T> Query<'a, T> {
         self
     }
 
-    /// Specify at which block hash to import the contract from. This is usable with
-    /// any network this object is importing from, but be aware that only archival
+    /// Specify at which block hash to query from. Note that only archival
     /// networks will have the full history while networks like mainnet or testnet
     /// only has the history from 5 or less epochs ago.
     pub fn block_hash(mut self, hash: CryptoHash) -> Self {
         self.block_ref = Some(BlockId::Hash(near_primitives::hash::CryptoHash(hash.0)).into());
+        self
+    }
+
+    /// Specify at which block [`Finality`] to query from.
+    pub fn finality(mut self, value: Finality) -> Self {
+        self.block_ref = Some(value.into());
         self
     }
 
@@ -87,7 +91,7 @@ where
 
 /// Trait used as a converter from WorkspaceRequest to near-rpc request, and
 /// from near-rpc response to a WorkspaceResult
-pub trait Queryable {
+trait Queryable {
     // TODO: associated default type is unstable. So for now, will require writing
     // the manual impls for query_request
     type QueryMethod: RpcMethod;

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -28,8 +28,6 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
 
-use futures::future::BoxFuture;
-
 use near_account_id::AccountId;
 use near_jsonrpc_client::methods::query::RpcQueryResponse;
 use near_jsonrpc_client::methods::{self, RpcMethod};
@@ -41,7 +39,7 @@ use crate::error::RpcErrorCode;
 use crate::operations::FunctionOwned;
 use crate::result::ViewResultDetails;
 use crate::rpc::client::Client;
-use crate::rpc::tool;
+use crate::rpc::{tool, BoxFuture};
 use crate::types::{AccessKey, AccessKeyInfo, Balance, BlockHeight, Finality, PublicKey};
 use crate::{AccountDetails, Block, CryptoHash, Result};
 

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -33,9 +33,7 @@ impl<'a, T> Query<'a, T> {
             block_ref: None,
         }
     }
-}
 
-impl<'a, T> Query<'a, T> {
     /// Specify at which block height to import the contract from. This is usable with
     /// any network this object is importing from, but be aware that only archival
     /// networks will have the full history while networks like mainnet or testnet
@@ -57,7 +55,7 @@ impl<'a, T> Query<'a, T> {
 
 impl<'a, T, R> std::future::IntoFuture for Query<'a, T>
 where
-    T: Queryable<Output = R> + 'static + Send + Sync,
+    T: Queryable<Output = R> + Send + Sync + 'static,
     <T as Queryable>::QueryMethod: RpcMethod + Debug + Send + Sync,
     <<T as Queryable>::QueryMethod as RpcMethod>::Response: Debug + Send + Sync,
     <<T as Queryable>::QueryMethod as RpcMethod>::Error: Debug + Display + Send + Sync,

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -51,6 +51,11 @@ impl<'a, T> Query<'a, T> {
         self.block_ref = Some(BlockId::Hash(near_primitives::hash::CryptoHash(hash.0)).into());
         self
     }
+
+    pub(crate) fn block_reference(mut self, value: BlockReference) -> Self {
+        self.block_ref = Some(value);
+        self
+    }
 }
 
 impl<'a, T, R> std::future::IntoFuture for Query<'a, T>

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -128,9 +128,9 @@ pub struct ViewState {
     prefix: Option<Vec<u8>>,
 }
 
-pub(crate) struct ViewAccessKey {
-    account_id: AccountId,
-    public_key: PublicKey,
+pub struct ViewAccessKey {
+    pub(crate) account_id: AccountId,
+    pub(crate) public_key: PublicKey,
 }
 
 pub(crate) struct ViewAccessKeyList {

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -110,7 +110,7 @@ pub struct ViewAccount {
 
 pub struct ViewBlock;
 
-pub(crate) struct ViewState {
+pub struct ViewState {
     account_id: AccountId,
     prefix: Option<Vec<u8>>,
 }
@@ -248,6 +248,24 @@ impl Queryable for ViewState {
             QueryResponseKind::ViewState(state) => Ok(tool::into_state_map(&state.values)?),
             _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
         }
+    }
+}
+
+impl<'a> Query<'a, ViewState> {
+    pub(crate) fn view_state(client: &'a Client, id: &AccountId) -> Self {
+        Self::new(
+            client,
+            ViewState {
+                account_id: id.clone(),
+                prefix: None,
+            },
+        )
+    }
+
+    /// Set the prefix for viewing the state.
+    pub fn prefix(mut self, value: &[u8]) -> Self {
+        self.method.prefix = Some(value.into());
+        self
     }
 }
 

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -1,30 +1,28 @@
-use std::future::{ready, Future, IntoFuture, Ready};
-use std::marker::PhantomData;
+use std::collections::HashMap;
+use std::fmt::{Debug, Display};
+use std::future::IntoFuture;
 
-use futures::future::AndThen;
-use futures::future::BoxFuture;
-use futures::future::TryFutureExt;
-// use futures::TryFuture;
+use futures::future::{BoxFuture, TryFutureExt};
 
 use near_account_id::AccountId;
-use near_jsonrpc_client::errors::JsonRpcError;
-use near_jsonrpc_client::methods::query::{RpcQueryError, RpcQueryRequest, RpcQueryResponse};
+use near_jsonrpc_client::methods::query::RpcQueryResponse;
 use near_jsonrpc_client::methods::{self, RpcMethod};
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
-use near_primitives::types::{BlockId, BlockReference};
-use near_primitives::views::QueryRequest;
+use near_primitives::types::{BlockId, BlockReference, StoreKey};
+use near_primitives::views::{BlockView, QueryRequest};
 
-use crate::error::{Error, RpcErrorCode};
+use crate::error::RpcErrorCode;
+use crate::operations::Function;
 use crate::rpc::client::Client;
-use crate::types::BlockHeight;
-use crate::{AccountDetails, CryptoHash, Result};
+use crate::types::{AccessKeyInfo, BlockHeight, PublicKey};
+use crate::{AccessKey, AccountDetails, Block, CryptoHash, Result};
+
+use super::tool;
 
 pub struct Query<'a, T> {
     pub(crate) client: &'a Client,
-    pub(crate) request: near_primitives::views::QueryRequest,
     pub(crate) block_ref: Option<BlockReference>,
-    // pub(crate) method: T,
-    pub(crate) _data: PhantomData<T>,
+    pub(crate) method: T,
 }
 
 // impl<'a, T> Query<'a, T> {
@@ -54,26 +52,11 @@ impl<'a, T> Query<'a, T> {
 impl<'a, T, R> IntoFuture for Query<'a, T>
 where
     T: Queryable<Output = R> + 'static,
-    <T as Queryable>::QueryMethod: RpcMethod + std::fmt::Debug,
-    <<T as Queryable>::QueryMethod as RpcMethod>::Response: std::fmt::Debug,
-    <<T as Queryable>::QueryMethod as RpcMethod>::Error: std::fmt::Debug,
-    // Fut: TryFuture<Error = Error>,
-    // F: FnOnce(QueryResponseKind) -> Fut,
-    // Self: Sized,
+    <T as Queryable>::QueryMethod: RpcMethod + Debug + Send + Sync,
+    <<T as Queryable>::QueryMethod as RpcMethod>::Response: Debug + Send + Sync,
+    <<T as Queryable>::QueryMethod as RpcMethod>::Error: Debug + Display + Send + Sync,
 {
     type Output = Result<R>;
-    // type IntoFuture = Ready<Self::Output>;
-    // type IntoFuture = AndThen<
-    //     impl Future<
-    //         Output = Result<
-    //             <RpcQueryRequest as RpcMethod>::Response,
-    //             JsonRpcError<<RpcQueryRequest as RpcMethod>::Error>,
-    //         >,
-    //     >,
-    //     impl Future<Output = Result<R, JsonRpcError<RpcQueryError>>>,
-    //     FnOnce(RpcQueryResponse) -> impl Future<Output = Result<R, JsonRpcError<RpcQueryError>>>,
-    // >;
-    // type IntoFuture = futures::future::IntoFuture;
 
     // TODO: boxed future required due to impl Trait as type alias being unstable. So once
     // https://github.com/rust-lang/rust/issues/63063 is resolved, we can move to that instead.
@@ -83,20 +66,19 @@ where
         let block_reference = self.block_ref.unwrap_or_else(BlockReference::latest);
         let fut = self
             .client
-            .query(methods::query::RpcQueryRequest {
-                block_reference,
-                request: self.request,
-            })
-            // .query(self.method.into_query_request(block_ref))
-            .map_ok(T::process_response)
-            .map_err(|e| RpcErrorCode::QueryFailure.custom(e));
-        // .and_then(|result| async move { Ok(T::into_value(result)) });
+            // query returns Future<Output = Result<Value, JsonRpcError>>
+            .query(self.method.into_query_request(block_reference))
+            // map the err to workspaces type: Future<Output = Result<Value, WorkspacesError>>
+            .map_err(|e| RpcErrorCode::QueryFailure.custom(e))
+            // map the val to workspaces type: Future<Output = Result<WorkspacesValue, WorkspacesError>>
+            .and_then(|resp| async move { T::process_response(resp) });
 
         Box::pin(fut)
-        // Box::pin(TryFutureExt::into_future(fut))
     }
 }
 
+/// Trait used as a converter from WorkspaceRequest to near-rpc request, and
+/// from near-rpc response to a WorkspaceResult
 pub trait Queryable {
     // TODO: associated default type is unstable. So for now, will require writing
     // the manual impls for query_request
@@ -107,24 +89,60 @@ pub trait Queryable {
     type Output;
 
     fn into_query_request(self, block_ref: BlockReference) -> Self::QueryMethod;
-    // fn process_response(query: <Self::QueryMethod as RpcMethod>::Response) -> Self::Output;
-    fn process_response(query: RpcQueryResponse) -> Self::Output;
+    fn process_response(query: <Self::QueryMethod as RpcMethod>::Response) -> Result<Self::Output>;
+    // fn process_response(query: RpcQueryResponse) -> Self::Output;
 }
 
-struct View;
-pub struct ViewCode {
+struct ViewFunction {
     account_id: AccountId,
+    function: Function<'static>,
+}
+
+pub struct ViewCode {
+    pub(crate) account_id: AccountId,
 }
 pub struct ViewAccount {
-    account_id: AccountId,
+    pub(crate) account_id: AccountId,
 }
 struct ViewBlock;
-struct ViewState;
-struct ViewAccessKey;
-struct ViewAccessKeyList;
+struct ViewState {
+    account_id: AccountId,
+    prefix: Option<Vec<u8>>,
+}
+struct ViewAccessKey {
+    account_id: AccountId,
+    public_key: PublicKey,
+}
+struct ViewAccessKeyList {
+    account_id: AccountId,
+}
+
+impl Queryable for ViewFunction {
+    type Output = Vec<u8>;
+    type QueryMethod = methods::query::RpcQueryRequest;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod {
+            block_reference,
+            request: QueryRequest::CallFunction {
+                account_id: self.account_id,
+                method_name: self.function.name.into(),
+                // TODO: result
+                args: self.function.args.unwrap().into(),
+            },
+        }
+    }
+
+    fn process_response(query: RpcQueryResponse) -> Result<Self::Output> {
+        match query.kind {
+            QueryResponseKind::ViewCode(contract) => Ok(contract.code),
+            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying account")),
+        }
+    }
+}
 
 impl Queryable for ViewCode {
-    type Output = Result<Vec<u8>>;
+    type Output = Vec<u8>;
     type QueryMethod = methods::query::RpcQueryRequest;
 
     fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
@@ -136,7 +154,7 @@ impl Queryable for ViewCode {
         }
     }
 
-    fn process_response(query: RpcQueryResponse) -> Self::Output {
+    fn process_response(query: RpcQueryResponse) -> Result<Self::Output> {
         match query.kind {
             QueryResponseKind::ViewCode(contract) => Ok(contract.code),
             _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying account")),
@@ -145,7 +163,7 @@ impl Queryable for ViewCode {
 }
 
 impl Queryable for ViewAccount {
-    type Output = Result<AccountDetails>;
+    type Output = AccountDetails;
     type QueryMethod = methods::query::RpcQueryRequest;
 
     fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
@@ -157,10 +175,90 @@ impl Queryable for ViewAccount {
         }
     }
 
-    fn process_response(query: RpcQueryResponse) -> Self::Output {
+    fn process_response(query: RpcQueryResponse) -> Result<Self::Output> {
         match query.kind {
             QueryResponseKind::ViewAccount(account) => Ok(account.into()),
             _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying account")),
+        }
+    }
+}
+
+impl Queryable for ViewBlock {
+    type QueryMethod = methods::block::RpcBlockRequest;
+    type Output = Block;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod { block_reference }
+    }
+
+    fn process_response(view: BlockView) -> Result<Self::Output> {
+        Ok(view.into())
+    }
+}
+
+impl Queryable for ViewState {
+    type QueryMethod = methods::query::RpcQueryRequest;
+    type Output = HashMap<Vec<u8>, Vec<u8>>;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod {
+            block_reference,
+            request: QueryRequest::ViewState {
+                account_id: self.account_id,
+                prefix: StoreKey::from(self.prefix.map(Vec::from).unwrap_or_default()),
+            },
+        }
+    }
+
+    fn process_response(query: <Self::QueryMethod as RpcMethod>::Response) -> Result<Self::Output> {
+        match query.kind {
+            QueryResponseKind::ViewState(state) => Ok(tool::into_state_map(&state.values)?),
+            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
+        }
+    }
+}
+
+impl Queryable for ViewAccessKey {
+    type QueryMethod = methods::query::RpcQueryRequest;
+    type Output = AccessKey;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod {
+            block_reference,
+            request: QueryRequest::ViewAccessKey {
+                account_id: self.account_id,
+                public_key: self.public_key.into(),
+            },
+        }
+    }
+
+    fn process_response(query: <Self::QueryMethod as RpcMethod>::Response) -> Result<Self::Output> {
+        match query.kind {
+            QueryResponseKind::AccessKey(key) => Ok(key.into()),
+            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
+        }
+    }
+}
+
+impl Queryable for ViewAccessKeyList {
+    type QueryMethod = methods::query::RpcQueryRequest;
+    type Output = Vec<AccessKeyInfo>;
+
+    fn into_query_request(self, block_reference: BlockReference) -> Self::QueryMethod {
+        Self::QueryMethod {
+            block_reference,
+            request: QueryRequest::ViewAccessKeyList {
+                account_id: self.account_id,
+            },
+        }
+    }
+
+    fn process_response(query: <Self::QueryMethod as RpcMethod>::Response) -> Result<Self::Output> {
+        match query.kind {
+            QueryResponseKind::AccessKeyList(keylist) => {
+                Ok(keylist.keys.into_iter().map(Into::into).collect())
+            }
+            _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying state")),
         }
     }
 }

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -14,11 +14,15 @@ use crate::error::RpcErrorCode;
 use crate::operations::FunctionOwned;
 use crate::result::ViewResultDetails;
 use crate::rpc::client::Client;
-use crate::types::{AccessKey, AccessKeyInfo, BlockHeight, PublicKey, Finality};
+use crate::types::{AccessKey, AccessKeyInfo, BlockHeight, Finality, PublicKey};
 use crate::{AccountDetails, Block, CryptoHash, Result};
 
 use super::tool;
 
+/// `Query` object allows creating queries into the network of our choice. This object is
+/// usually given from making calls from other functions such as [`view_state`].
+///
+/// [`view_state`]: crate::worker::Worker::view_state
 pub struct Query<'a, T> {
     pub(crate) method: T,
     pub(crate) client: &'a Client,

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -4,7 +4,9 @@ use std::path::Path;
 use near_primitives::views::AccountView;
 
 use crate::error::ErrorKind;
-use crate::rpc::query::{Query, ViewAccessKey, ViewAccount, ViewCode, ViewFunction, ViewState};
+use crate::rpc::query::{
+    Query, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewCode, ViewFunction, ViewState,
+};
 use crate::types::{AccountId, Balance, InMemorySigner, PublicKey, SecretKey};
 use crate::{BlockHeight, CryptoHash, Network, Worker};
 
@@ -119,6 +121,19 @@ impl Account {
             ViewAccessKey {
                 account_id: self.id().clone(),
                 public_key: pk.clone(),
+            },
+        )
+    }
+
+    /// Views all the [`AccessKey`]s of the current account. This will return a list of
+    /// [`AccessKey`]s along with each associated [`PublicKey`].
+    ///
+    /// [`AccessKey`]: crate::types::AccessKey
+    pub fn view_access_keys(&self) -> Query<'_, ViewAccessKeyList> {
+        Query::new(
+            self.worker.client(),
+            ViewAccessKeyList {
+                account_id: self.id.clone(),
             },
         )
     }
@@ -288,6 +303,14 @@ impl Contract {
     /// Views the current contract's access key, given the [`PublicKey`] associated to it.
     pub fn view_access_key(&self, pk: &PublicKey) -> Query<'_, ViewAccessKey> {
         self.account.view_access_key(pk)
+    }
+
+    /// Views all the [`AccessKey`]s of the current contract. This will return a list of
+    /// [`AccessKey`]s along with each associated [`PublicKey`].
+    ///
+    /// [`AccessKey`]: crate::types::AccessKey
+    pub fn view_access_keys(&self) -> Query<'_, ViewAccessKeyList> {
+        self.account.view_access_keys()
     }
 
     /// Deletes the current contract, and returns the execution details of this

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::fmt;
 use std::path::Path;
 
@@ -9,8 +8,8 @@ use crate::rpc::query::{Query, ViewCode, ViewFunction, ViewState};
 use crate::types::{AccountId, Balance, InMemorySigner, SecretKey};
 use crate::{CryptoHash, Network, Worker};
 
-use crate::operations::{CallTransaction, CreateAccountTransaction, FunctionOwned, Transaction};
-use crate::result::{Execution, ExecutionFinalResult, Result, ViewResultDetails};
+use crate::operations::{CallTransaction, CreateAccountTransaction, Transaction};
+use crate::result::{Execution, ExecutionFinalResult, Result};
 
 /// `Account` is directly associated to an account in the network provided by the
 /// [`Worker`] that creates it. This type offers methods to interact with any
@@ -84,13 +83,8 @@ impl Account {
 
     /// View call to a specified contract function. Returns a result which can
     /// be deserialized into borsh or JSON.
-    pub async fn view(
-        &self,
-        contract_id: &AccountId,
-        function: &str,
-        args: Vec<u8>,
-    ) -> Result<ViewResultDetails> {
-        self.worker.view(contract_id, function, args).await
+    pub fn view(&self, contract_id: &AccountId, function: &str) -> Query<'_, ViewFunction> {
+        self.worker.view(contract_id, function)
     }
 
     /// Transfer NEAR to an account specified by `receiver_id` with the amount
@@ -262,14 +256,7 @@ impl Contract {
     /// Call a view function into the current contract. Returns a result which can
     /// be deserialized into borsh or JSON.
     pub fn view(&self, function: &str) -> Query<'_, ViewFunction> {
-        // self.account.worker.view(self.id(), function, args).await
-        Query::new(
-            self.account.worker.client(),
-            ViewFunction {
-                account_id: self.id().clone(),
-                function: FunctionOwned::new(function.into()),
-            },
-        )
+        self.account.view(self.id(), function)
     }
 
     /// View the WASM code bytes of this contract.

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use near_primitives::views::AccountView;
 
 use crate::error::ErrorKind;
-use crate::rpc::query::{Query, ViewFunction};
+use crate::rpc::query::{Query, ViewCode, ViewFunction, ViewState};
 use crate::types::{AccountId, Balance, InMemorySigner, SecretKey};
 use crate::{CryptoHash, Network, Worker};
 
@@ -273,13 +273,13 @@ impl Contract {
     }
 
     /// View the WASM code bytes of this contract.
-    pub async fn view_code(&self) -> Result<Vec<u8>> {
-        self.account.worker.view_code(self.id()).await
+    pub fn view_code(&self) -> Query<'_, ViewCode> {
+        self.account.worker.view_code(self.id())
     }
 
     /// View a contract's state map of key value pairs.
-    pub async fn view_state(&self, prefix: Option<&[u8]>) -> Result<HashMap<Vec<u8>, Vec<u8>>> {
-        self.account.worker.view_state(self.id(), prefix).await
+    pub fn view_state(&self) -> Query<'_, ViewState> {
+        self.account.worker.view_state(self.id())
     }
 
     /// Views the current contract's details such as balance and storage usage.

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -4,8 +4,8 @@ use std::path::Path;
 use near_primitives::views::AccountView;
 
 use crate::error::ErrorKind;
-use crate::rpc::query::{Query, ViewAccount, ViewCode, ViewFunction, ViewState};
-use crate::types::{AccountId, Balance, InMemorySigner, SecretKey};
+use crate::rpc::query::{Query, ViewAccessKey, ViewAccount, ViewCode, ViewFunction, ViewState};
+use crate::types::{AccountId, Balance, InMemorySigner, PublicKey, SecretKey};
 use crate::{BlockHeight, CryptoHash, Network, Worker};
 
 use crate::operations::{CallTransaction, CreateAccountTransaction, Transaction};
@@ -110,6 +110,17 @@ impl Account {
     /// Views the current account's details such as balance and storage usage.
     pub fn view_account(&self) -> Query<'_, ViewAccount> {
         self.worker.view_account(&self.id)
+    }
+
+    /// Views the current accounts's access key, given the [`PublicKey`] associated to it.
+    pub fn view_access_key(&self, pk: &PublicKey) -> Query<'_, ViewAccessKey> {
+        Query::new(
+            self.worker.client(),
+            ViewAccessKey {
+                account_id: self.id().clone(),
+                public_key: pk.clone(),
+            },
+        )
     }
 
     /// Create a new sub account. Returns a [`CreateAccountTransaction`] object
@@ -272,6 +283,11 @@ impl Contract {
     /// Views the current contract's details such as balance and storage usage.
     pub fn view_account(&self) -> Query<'_, ViewAccount> {
         self.account.worker.view_account(self.id())
+    }
+
+    /// Views the current contract's access key, given the [`PublicKey`] associated to it.
+    pub fn view_access_key(&self, pk: &PublicKey) -> Query<'_, ViewAccessKey> {
+        self.account.view_access_key(pk)
     }
 
     /// Deletes the current contract, and returns the execution details of this

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -74,7 +74,7 @@ impl Account {
         &'a self,
         contract_id: &AccountId,
         function: &'b str,
-    ) -> CallTransaction<'a, 'b> {
+    ) -> CallTransaction<'a> {
         CallTransaction::new(
             &self.worker,
             contract_id.to_owned(),
@@ -275,7 +275,7 @@ impl Contract {
     ///
     /// If we want to make use of the contract's secret key as a signer to call
     /// into another contract, use `contract.as_account().call` instead.
-    pub fn call<'a>(&self, function: &'a str) -> CallTransaction<'_, 'a> {
+    pub fn call(&self, function: &str) -> CallTransaction<'_> {
         self.account.call(self.id(), function)
     }
 

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -206,10 +206,10 @@ pub struct AccessKey {
     /// NOTE: In some cases the access key needs to be recreated. If the new access key reuses the
     /// same public key, the nonce of the new access key should be equal to the nonce of the old
     /// access key. It's required to avoid replaying old transactions again.
-    nonce: Nonce,
+    pub nonce: Nonce,
 
     /// Defines permissions for this access key.
-    permission: AccessKeyPermission,
+    pub permission: AccessKeyPermission,
 }
 
 impl AccessKey {
@@ -253,7 +253,7 @@ impl From<near_primitives::views::AccessKeyInfoView> for AccessKeyInfo {
 
 /// Defines permissions for AccessKey
 #[derive(Clone, Debug)]
-enum AccessKeyPermission {
+pub enum AccessKeyPermission {
     FunctionCall(FunctionCallPermission),
 
     /// Grants full access to the account.

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -326,3 +326,29 @@ impl From<near_primitives::views::AccessKeyView> for AccessKey {
         }
     }
 }
+
+/// Finality of a transaction or block in which transaction is included in. For more info
+/// go to the [NEAR finality](https://docs.near.org/docs/concepts/transaction#finality) docs.
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum Finality {
+    /// Optimistic finality. The latest block recorded on the node that responded to our query
+    /// (<1 second delay after the transaction is submitted).
+    Optimistic,
+    /// Near-final finality. Similiarly to `Final` finality, but delay should be roughly 1 second.
+    DoomSlug,
+    /// Final finality. The block that has been validated on at least 66% of the nodes in the
+    /// network. (At max, should be 2 second delay after the transaction is submitted.)
+    Final,
+}
+
+impl From<Finality> for near_primitives::types::BlockReference {
+    fn from(value: Finality) -> Self {
+        let value = match value {
+            Finality::Optimistic => near_primitives::types::Finality::None,
+            Finality::DoomSlug => near_primitives::types::Finality::DoomSlug,
+            Finality::Final => near_primitives::types::Finality::Final,
+        };
+        value.into()
+    }
+}

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -1,6 +1,6 @@
 use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo};
 use crate::network::{Info, Sandbox};
-use crate::operations::FunctionOwned;
+use crate::operations::Function;
 use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
@@ -67,11 +67,19 @@ where
 
     /// Call into a contract's view function.
     pub fn view(&self, contract_id: &AccountId, function: &str) -> Query<'_, ViewFunction> {
+        self.view_by_function(contract_id, Function::new(function))
+    }
+
+    pub(crate) fn view_by_function(
+        &self,
+        contract_id: &AccountId,
+        function: Function,
+    ) -> Query<'_, ViewFunction> {
         Query::new(
             self.client(),
             ViewFunction {
                 account_id: contract_id.clone(),
-                function: FunctionOwned::new(function.into()),
+                function,
             },
         )
     }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -1,9 +1,10 @@
 use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo};
 use crate::network::{Info, Sandbox};
-use crate::result::{ExecutionFinalResult, Result, ViewResultDetails};
+use crate::operations::FunctionOwned;
+use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
-use crate::rpc::query::{Query, ViewCode, ViewState};
+use crate::rpc::query::{Query, ViewCode, ViewFunction, ViewState};
 use crate::types::{AccountId, Gas, InMemorySigner};
 use crate::worker::Worker;
 use crate::{Account, Block, Contract};
@@ -63,15 +64,14 @@ where
     }
 
     /// Call into a contract's view function.
-    pub async fn view(
-        &self,
-        contract_id: &AccountId,
-        function: &str,
-        args: Vec<u8>,
-    ) -> Result<ViewResultDetails> {
-        self.client()
-            .view(contract_id.clone(), function.into(), args)
-            .await
+    pub fn view(&self, contract_id: &AccountId, function: &str) -> Query<'_, ViewFunction> {
+        Query::new(
+            self.client(),
+            ViewFunction {
+                account_id: contract_id.clone(),
+                function: FunctionOwned::new(function.into()),
+            },
+        )
     }
 
     /// View the WASM code bytes of a contract on the network.

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -4,7 +4,7 @@ use crate::operations::FunctionOwned;
 use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
-use crate::rpc::query::{Query, ViewCode, ViewFunction, ViewState};
+use crate::rpc::query::{Query, ViewBlock, ViewCode, ViewFunction, ViewState};
 use crate::types::{AccountId, Gas, InMemorySigner};
 use crate::worker::Worker;
 use crate::{Account, Block, Contract};
@@ -91,9 +91,10 @@ where
         Query::view_state(self.client(), contract_id)
     }
 
-    /// View the latest block from the network
-    pub async fn view_latest_block(&self) -> Result<Block> {
-        self.client().view_block(None).await.map(Into::into)
+    /// View the block from the network. Supply additional parameters such as `block_height`
+    /// or `block_hash` to get the block.
+    pub fn view_block(&self) -> Query<'_, ViewBlock> {
+        Query::new(self.client(), ViewBlock)
     }
 
     /// Transfer tokens from one account to another. The signer is the account

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -3,13 +3,13 @@ use crate::network::{Info, Sandbox};
 use crate::result::{ExecutionFinalResult, Result, ViewResultDetails};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
+use crate::rpc::query::{Query, ViewCode, ViewState};
 use crate::types::{AccountId, Gas, InMemorySigner};
 use crate::worker::Worker;
 use crate::{Account, Block, Contract};
 use crate::{AccountDetails, Network};
 
 use near_primitives::types::Balance;
-use std::collections::HashMap;
 
 impl<T: ?Sized> Clone for Worker<T> {
     fn clone(&self) -> Self {
@@ -75,22 +75,20 @@ where
     }
 
     /// View the WASM code bytes of a contract on the network.
-    pub async fn view_code(&self, contract_id: &AccountId) -> Result<Vec<u8>> {
-        let code_view = self.client().view_code(contract_id.clone(), None).await?;
-        Ok(code_view.code)
+    pub fn view_code(&self, contract_id: &AccountId) -> Query<'_, ViewCode> {
+        Query::new(
+            self.client(),
+            ViewCode {
+                account_id: contract_id.clone(),
+            },
+        )
     }
 
     /// View the state of a account/contract on the network. This will return the internal
     /// state of the account in the form of a map of key-value pairs; where STATE contains
     /// info on a contract's internal data.
-    pub async fn view_state(
-        &self,
-        contract_id: &AccountId,
-        prefix: Option<&[u8]>,
-    ) -> Result<HashMap<Vec<u8>, Vec<u8>>> {
-        self.client()
-            .view_state(contract_id.clone(), prefix, None)
-            .await
+    pub fn view_state(&self, contract_id: &AccountId) -> Query<'_, ViewState> {
+        Query::view_state(self.client(), contract_id)
     }
 
     /// View the latest block from the network

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -5,8 +5,8 @@ use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
 use crate::rpc::query::{
-    Query, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock, ViewCode, ViewFunction,
-    ViewState,
+    GasPrice, Query, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock, ViewCode,
+    ViewFunction, ViewState,
 };
 use crate::types::{AccountId, Gas, InMemorySigner, PublicKey};
 use crate::worker::Worker;
@@ -164,6 +164,10 @@ where
                 account_id: account_id.clone(),
             },
         )
+    }
+
+    pub fn gas_price(&self) -> Query<'_, GasPrice> {
+        Query::new(self.client(), GasPrice)
     }
 }
 

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -4,8 +4,10 @@ use crate::operations::FunctionOwned;
 use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
-use crate::rpc::query::{Query, ViewAccount, ViewBlock, ViewCode, ViewFunction, ViewState};
-use crate::types::{AccountId, Gas, InMemorySigner};
+use crate::rpc::query::{
+    Query, ViewAccessKey, ViewAccount, ViewBlock, ViewCode, ViewFunction, ViewState,
+};
+use crate::types::{AccountId, Gas, InMemorySigner, PublicKey};
 use crate::worker::Worker;
 use crate::{Account, Contract, Network};
 
@@ -94,6 +96,20 @@ where
     /// or `block_hash` to get the block.
     pub fn view_block(&self) -> Query<'_, ViewBlock> {
         Query::new(self.client(), ViewBlock)
+    }
+
+    /// Views the [`AccessKey`] of the account specified by [`AccountId`] associated with
+    /// the [`PublicKey`]
+    ///
+    /// [`AccessKey`]: crate::types::AccessKey
+    pub fn view_access_key(&self, id: &AccountId, pk: &PublicKey) -> Query<'_, ViewAccessKey> {
+        Query::new(
+            self.client(),
+            ViewAccessKey {
+                account_id: id.clone(),
+                public_key: pk.clone(),
+            },
+        )
     }
 
     /// Transfer tokens from one account to another. The signer is the account

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -3,16 +3,13 @@ use crate::network::{Info, Sandbox};
 use crate::result::{ExecutionFinalResult, Result, ViewResultDetails};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
-use crate::rpc::query::{Query, ViewAccount, ViewCode};
 use crate::types::{AccountId, Gas, InMemorySigner};
 use crate::worker::Worker;
 use crate::{Account, Block, Contract};
 use crate::{AccountDetails, Network};
 
 use near_primitives::types::Balance;
-use near_primitives::views::QueryRequest;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 
 impl<T: ?Sized> Clone for Worker<T> {
     fn clone(&self) -> Self {
@@ -99,22 +96,6 @@ where
     /// View the latest block from the network
     pub async fn view_latest_block(&self) -> Result<Block> {
         self.client().view_block(None).await.map(Into::into)
-    }
-
-    pub fn c_view_code<'a>(&'a self, account_id: AccountId) -> Query<'a, ViewCode> {
-        Query {
-            client: self.client(),
-            block_ref: None,
-            method: ViewCode { account_id },
-        }
-    }
-
-    pub fn c_view_account(&self, account_id: AccountId) -> Query<'_, ViewAccount> {
-        Query {
-            client: self.client(),
-            block_ref: None,
-            method: ViewAccount { account_id },
-        }
     }
 
     /// Transfer tokens from one account to another. The signer is the account

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -3,13 +3,16 @@ use crate::network::{Info, Sandbox};
 use crate::result::{ExecutionFinalResult, Result, ViewResultDetails};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
+use crate::rpc::query::{Query, ViewAccount, ViewCode};
 use crate::types::{AccountId, Gas, InMemorySigner};
 use crate::worker::Worker;
 use crate::{Account, Block, Contract};
 use crate::{AccountDetails, Network};
 
 use near_primitives::types::Balance;
+use near_primitives::views::QueryRequest;
 use std::collections::HashMap;
+use std::marker::PhantomData;
 
 impl<T: ?Sized> Clone for Worker<T> {
     fn clone(&self) -> Self {
@@ -96,6 +99,22 @@ where
     /// View the latest block from the network
     pub async fn view_latest_block(&self) -> Result<Block> {
         self.client().view_block(None).await.map(Into::into)
+    }
+
+    pub fn c_view_code<'a>(&'a self, account_id: AccountId) -> Query<'a, ViewCode> {
+        Query {
+            client: self.client(),
+            block_ref: None,
+            method: ViewCode { account_id },
+        }
+    }
+
+    pub fn c_view_account(&self, account_id: AccountId) -> Query<'_, ViewAccount> {
+        Query {
+            client: self.client(),
+            block_ref: None,
+            method: ViewAccount { account_id },
+        }
     }
 
     /// Transfer tokens from one account to another. The signer is the account

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -5,7 +5,8 @@ use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
 use crate::rpc::query::{
-    Query, ViewAccessKey, ViewAccount, ViewBlock, ViewCode, ViewFunction, ViewState,
+    Query, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock, ViewCode, ViewFunction,
+    ViewState,
 };
 use crate::types::{AccountId, Gas, InMemorySigner, PublicKey};
 use crate::worker::Worker;
@@ -108,6 +109,19 @@ where
             ViewAccessKey {
                 account_id: id.clone(),
                 public_key: pk.clone(),
+            },
+        )
+    }
+
+    /// Views all the [`AccessKey`]s of the account specified by [`AccountId`]. This will
+    /// return a list of [`AccessKey`]s along with the associated [`PublicKey`].
+    ///
+    /// [`AccessKey`]: crate::types::AccessKey
+    pub fn view_access_keys(&self, id: &AccountId) -> Query<'_, ViewAccessKeyList> {
+        Query::new(
+            self.client(),
+            ViewAccessKeyList {
+                account_id: id.clone(),
             },
         )
     }

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -43,11 +43,7 @@ async fn test_dev_deploy() -> anyhow::Result<()> {
         .await?
         .into_result()?;
 
-    let actual: NftMetadata = contract
-        .view("nft_metadata")
-        .args(Vec::new())
-        .await?
-        .json()?;
+    let actual: NftMetadata = contract.view("nft_metadata").await?.json()?;
 
     assert_eq!(actual, expected());
 

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -43,7 +43,11 @@ async fn test_dev_deploy() -> anyhow::Result<()> {
         .await?
         .into_result()?;
 
-    let actual: NftMetadata = contract.view("nft_metadata", Vec::new()).await?.json()?;
+    let actual: NftMetadata = contract
+        .view("nft_metadata")
+        .args(Vec::new())
+        .await?
+        .json()?;
 
     assert_eq!(actual, expected());
 

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -34,7 +34,7 @@ async fn view_status_state(
         .await?
         .into_result()?;
 
-    let mut state_items = contract.view_state(None).await?;
+    let mut state_items = contract.view_state().await?;
     let state = state_items
         .remove(b"STATE".as_slice())
         .ok_or_else(|| anyhow::anyhow!("Could not retrieve STATE"))?;

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -75,15 +75,10 @@ async fn test_patch_state() -> anyhow::Result<()> {
         .await?;
 
     let status: String = worker
-        .view(
-            &contract_id,
-            "get_status",
-            json!({
-                "account_id": "alice.near",
-            })
-            .to_string()
-            .into_bytes(),
-        )
+        .view(&contract_id, "get_status")
+        .args_json(json!({
+            "account_id": "alice.near",
+        }))
         .await?
         .json()?;
 


### PR DESCRIPTION
This adds the async builder `Query` which allows doing view calls into contract state, account, access keys, code, the view function call, and block. This uses `IntoFuture` to allow calling into `.await` at any point in the builder. Note, that `Query` builder takes a generic `<T>` for the method like `ViewState` since we can define custom builder functions per method type by doing `impl Query<ViewState> { ... }`

cc @matklad if you want to review my use of `IntoFuture` since you initially suggested it