### PR TITLE
feat: add `NetworkBuilder` impl for mainnet, betanet and testnet

### DIFF
--- a/workspaces/src/network/betanet.rs
+++ b/workspaces/src/network/betanet.rs
@@ -1,8 +1,11 @@
+use crate::network::builder::{FromNetworkBuilder, NetworkBuilder};
 use crate::network::{Info, NetworkClient, NetworkInfo};
 use crate::rpc::client::Client;
+
 use std::path::PathBuf;
 
-const RPC_URL: &str = "https://rpc.betanet.near.org";
+/// URL to the betanet RPC node provided by near.org.
+pub const RPC_URL: &str = "https://rpc.betanet.near.org";
 
 /// Betanet related configuration for interacting with betanet. Look at
 /// [`workspaces::betanet`] for how to spin up a [`Worker`] that can be
@@ -20,18 +23,20 @@ pub struct Betanet {
     info: Info,
 }
 
-impl Betanet {
-    pub(crate) async fn new() -> crate::result::Result<Self> {
-        let client = Client::new(RPC_URL);
+#[async_trait::async_trait]
+impl FromNetworkBuilder for Betanet {
+    async fn from_builder<'a>(build: NetworkBuilder<'a, Self>) -> crate::result::Result<Self> {
+        let rpc_url = build.rpc_addr.unwrap_or_else(|| RPC_URL.into());
+        let client = Client::new(&rpc_url);
         client.wait_for_rpc().await?;
 
         Ok(Self {
             client,
             info: Info {
-                name: "betanet".into(),
+                name: build.name.into(),
                 root_id: "near".parse().unwrap(),
                 keystore_path: PathBuf::from(".near-credentials/betanet/"),
-                rpc_url: RPC_URL.into(),
+                rpc_url,
             },
         })
     }

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -2,16 +2,17 @@
 //!
 //! Currently the builtin network types are [`Mainnet`], [`Testnet`], and [`Sandbox`].
 
-mod betanet;
 mod config;
 mod info;
-mod mainnet;
 mod sandbox;
 mod server;
-mod testnet;
 
 pub(crate) mod builder;
 pub(crate) mod variants;
+
+pub mod betanet;
+pub mod mainnet;
+pub mod testnet;
 
 pub(crate) use variants::DEV_ACCOUNT_SEED;
 

--- a/workspaces/src/worker/mod.rs
+++ b/workspaces/src/worker/mod.rs
@@ -43,37 +43,37 @@ impl<T: fmt::Debug> fmt::Debug for Worker<T> {
 }
 
 /// Spin up a new sandbox instance, and grab a [`Worker`] that interacts with it.
-pub fn sandbox() -> NetworkBuilder<'static, Sandbox> {
+pub fn sandbox<'a>() -> NetworkBuilder<'a, Sandbox> {
     NetworkBuilder::new("sandbox")
 }
 
 /// Connect to the [testnet](https://explorer.testnet.near.org/) network, and grab
 /// a [`Worker`] that can interact with it.
-pub async fn testnet() -> Result<Worker<Testnet>> {
-    Ok(Worker::new(Testnet::new().await?))
+pub fn testnet<'a>() -> NetworkBuilder<'a, Testnet> {
+    NetworkBuilder::new("testnet")
 }
 
 /// Connect to the [testnet archival](https://near-nodes.io/intro/node-types#archival-node)
 /// network, and grab a [`Worker`] that can interact with it.
-pub async fn testnet_archival() -> Result<Worker<Testnet>> {
-    Ok(Worker::new(Testnet::archival().await?))
+pub fn testnet_archival<'a>() -> NetworkBuilder<'a, Testnet> {
+    NetworkBuilder::new("testnet-archival").rpc_addr(crate::network::testnet::ARCHIVAL_URL)
 }
 
 /// Connect to the [mainnet](https://explorer.near.org/) network, and grab
 /// a [`Worker`] that can interact with it.
-pub async fn mainnet() -> Result<Worker<Mainnet>> {
-    Ok(Worker::new(Mainnet::new().await?))
+pub fn mainnet<'a>() -> NetworkBuilder<'a, Mainnet> {
+    NetworkBuilder::new("mainnet")
 }
 
 /// Connect to the [mainnet archival](https://near-nodes.io/intro/node-types#archival-node)
 /// network, and grab a [`Worker`] that can interact with it.
-pub async fn mainnet_archival() -> Result<Worker<Mainnet>> {
-    Ok(Worker::new(Mainnet::archival().await?))
+pub fn mainnet_archival<'a>() -> NetworkBuilder<'a, Mainnet> {
+    NetworkBuilder::new("mainnet-archival").rpc_addr(crate::network::mainnet::ARCHIVAL_URL)
 }
 
 /// Connect to the betanet network, and grab a [`Worker`] that can interact with it.
-pub async fn betanet() -> Result<Worker<Betanet>> {
-    Ok(Worker::new(Betanet::new().await?))
+pub fn betanet<'a>() -> NetworkBuilder<'a, Betanet> {
+    NetworkBuilder::new("betanet")
 }
 
 /// Run a locally scoped task where a [`sandbox`] instanced [`Worker`] is supplied.


### PR DESCRIPTION
Second part of https://github.com/near/workspaces-rs/pull/220

This implements the `NetworkBuilder` for testnet and mainnet networks so that these networks can customize the RPC urls to point to Pagoda ones or their own RPC. Also made, `RPC_URL` and `ARCHIVAL_URL` constants public, since users can make use of them if they want to.