### PR TITLE
chore: Expose error creation methods

### DIFF
--- a/workspaces/src/error/impls.rs
+++ b/workspaces/src/error/impls.rs
@@ -38,7 +38,7 @@ impl Error {
     /// Construct a workspaces [`Error`] with the full details of an error which includes
     /// the internal error it references, the custom error message with further context
     /// and the [`ErrorKind`] that represents the category of error.
-    pub fn full<T, E>(kind: ErrorKind, msg: T, error: E) -> Self
+    pub(crate) fn full<T, E>(kind: ErrorKind, msg: T, error: E) -> Self
     where
         T: Into<Cow<'static, str>>,
         E: Into<Box<dyn std::error::Error + Send + Sync>>,

--- a/workspaces/src/error/impls.rs
+++ b/workspaces/src/error/impls.rs
@@ -35,7 +35,10 @@ impl Error {
         }
     }
 
-    pub(crate) fn full<T, E>(kind: ErrorKind, msg: T, error: E) -> Self
+    /// Construct a workspaces [`Error`] with the full details of an error which includes
+    /// the internal error it references, the custom error message with further context
+    /// and the [`ErrorKind`] that represents the category of error.
+    pub fn full<T, E>(kind: ErrorKind, msg: T, error: E) -> Self
     where
         T: Into<Cow<'static, str>>,
         E: Into<Box<dyn std::error::Error + Send + Sync>>,
@@ -49,7 +52,10 @@ impl Error {
         }
     }
 
-    pub(crate) fn custom<E>(kind: ErrorKind, error: E) -> Self
+    /// Construct a workspaces [`Error`] with the details of an error which includes
+    /// the internal error it references and the [`ErrorKind`] that represents the
+    /// category of error.
+    pub fn custom<E>(kind: ErrorKind, error: E) -> Self
     where
         E: Into<Box<dyn std::error::Error + Send + Sync>>,
     {
@@ -61,7 +67,10 @@ impl Error {
         }
     }
 
-    pub(crate) fn message<T>(kind: ErrorKind, msg: T) -> Self
+    /// Construct a workspaces [`Error`] with the details of an error which includes
+    /// the custom error message with further context and the [`ErrorKind`] that
+    /// represents the category of error.
+    pub fn message<T>(kind: ErrorKind, msg: T) -> Self
     where
         T: Into<Cow<'static, str>>,
     {
@@ -73,7 +82,9 @@ impl Error {
         }
     }
 
-    pub(crate) fn simple(kind: ErrorKind) -> Self {
+    /// Construct a workspaces [`Error`] with the details of an error which only
+    /// includes the [`ErrorKind`] that represents the category of error.
+    pub fn simple(kind: ErrorKind) -> Self {
         Self {
             repr: ErrorRepr::Simple(kind),
         }

--- a/workspaces/src/error/mod.rs
+++ b/workspaces/src/error/mod.rs
@@ -27,6 +27,9 @@ pub enum ErrorKind {
     /// An error from converting data.
     #[error("DataConversion")]
     DataConversion,
+    /// An error that cannot be categorized into the other error kinds.
+    #[error("Other")]
+    Other,
 }
 
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
addresses https://github.com/near/workspaces-rs/issues/194.

Thought it would be nice to have these be exposed since the errors are in good shape to be used at higher levels if users want to make use of them to build their own errors. Also added the `Other` variant to `ErrorKind` since users can have different categories of errors other than the ones defined for their higher level workspaces libraries. Any objections to adding this?