### PR TITLE
fix: Use public keys for cached nonces

### DIFF
--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -22,6 +22,7 @@ use near_primitives::transaction::{
 };
 use near_primitives::views::FinalExecutionOutcomeView;
 use std::convert::TryInto;
+use std::fmt;
 use std::future::IntoFuture;
 use std::task::Poll;
 
@@ -503,6 +504,15 @@ impl<'a> TransactionStatus<'a> {
     /// Reference [`CryptoHash`] to the submitted transaction, pending completion.
     pub fn hash(&self) -> &CryptoHash {
         &self.hash
+    }
+}
+
+impl<'a> fmt::Debug for TransactionStatus<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TransactionStatus")
+            .field("sender_id", &self.sender_id)
+            .field("hash", &self.hash)
+            .finish()
     }
 }
 

--- a/workspaces/src/result.rs
+++ b/workspaces/src/result.rs
@@ -39,6 +39,7 @@ impl<T> Execution<T> {
         self.into_result().unwrap()
     }
 
+    #[allow(clippy::result_large_err)]
     pub fn into_result(self) -> Result<T, ExecutionFailure> {
         self.details.into_result()?;
         Ok(self.result)
@@ -194,6 +195,7 @@ impl ExecutionFinalResult {
     }
 
     /// Converts this object into a [`Result`] holding either [`ExecutionSuccess`] or [`ExecutionFailure`].
+    #[allow(clippy::result_large_err)]
     pub fn into_result(self) -> Result<ExecutionSuccess, ExecutionFailure> {
         match self.status {
             FinalExecutionStatus::SuccessValue(value) => Ok(ExecutionResult {

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -40,7 +40,7 @@ pub struct Client {
     rpc_addr: String,
     rpc_client: JsonRpcClient,
     /// AccessKey nonces to reference when sending transactions.
-    pub(crate) access_key_nonces: RwLock<HashMap<AccountId, AtomicU64>>,
+    pub(crate) access_key_nonces: RwLock<HashMap<near_crypto::PublicKey, AtomicU64>>,
 }
 
 impl Client {
@@ -377,12 +377,12 @@ async fn fetch_tx_nonce(
     public_key: near_crypto::PublicKey,
 ) -> Result<(CryptoHash, Nonce)> {
     let nonces = client.access_key_nonces.read().await;
-    if let Some(nonce) = nonces.get(&account_id) {
+    if let Some(nonce) = nonces.get(&public_key) {
         cached_nonce(nonce, client).await
     } else {
         drop(nonces);
         let mut nonces = client.access_key_nonces.write().await;
-        match nonces.entry(account_id.clone()) {
+        match nonces.entry(public_key.clone()) {
             // case where multiple writers end up at the same lock acquisition point and tries
             // to overwrite the cached value that a previous writer already wrote.
             Entry::Occupied(entry) => cached_nonce(entry.get(), client).await,
@@ -411,7 +411,7 @@ where
 
 pub(crate) async fn send_tx(
     client: &Client,
-    receiver_id: &AccountId,
+    public_key: near_crypto::PublicKey,
     tx: SignedTransaction,
 ) -> Result<FinalExecutionOutcomeView> {
     let result = client
@@ -429,24 +429,12 @@ pub(crate) async fn send_tx(
     ))) = &result
     {
         let mut nonces = client.access_key_nonces.write().await;
-        if let Entry::Occupied(entry) = nonces.entry(receiver_id.clone()) {
+        if let Entry::Occupied(entry) = nonces.entry(public_key.clone()) {
             entry.remove_entry();
         }
     }
 
     result.map_err(|e| RpcErrorCode::BroadcastTxFailure.custom(e))
-}
-
-pub(crate) async fn send_tx_and_retry<T, F>(
-    client: &Client,
-    receiver_id: &AccountId,
-    task: F,
-) -> Result<FinalExecutionOutcomeView>
-where
-    F: Fn() -> T,
-    T: core::future::Future<Output = Result<SignedTransaction>>,
-{
-    retry(|| async { send_tx(client, receiver_id, task().await?).await }).await
 }
 
 pub(crate) async fn send_batch_tx_and_retry(
@@ -456,18 +444,23 @@ pub(crate) async fn send_batch_tx_and_retry(
     actions: Vec<Action>,
 ) -> Result<FinalExecutionOutcomeView> {
     let signer = signer.inner();
-    send_tx_and_retry(client, receiver_id, || async {
+    retry(|| async {
         let (block_hash, nonce) =
             fetch_tx_nonce(client, signer.account_id.clone(), signer.public_key()).await?;
 
-        Ok(SignedTransaction::from_actions(
-            nonce,
-            signer.account_id.clone(),
-            receiver_id.clone(),
-            &signer as &dyn Signer,
-            actions.clone(),
-            block_hash,
-        ))
+        send_tx(
+            client,
+            signer.public_key(),
+            SignedTransaction::from_actions(
+                nonce,
+                signer.account_id.clone(),
+                receiver_id.clone(),
+                &signer as &dyn Signer,
+                actions.clone(),
+                block_hash,
+            ),
+        )
+        .await
     })
     .await
 }

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -237,6 +237,7 @@ impl AccessKey {
 }
 
 /// Similar to an [`AccessKey`], but also has the [`PublicKey`] associated with it.
+#[derive(Clone, Debug)]
 pub struct AccessKeyInfo {
     pub public_key: PublicKey,
     pub access_key: AccessKey,
@@ -333,7 +334,7 @@ impl From<near_primitives::views::AccessKeyView> for AccessKey {
 
 /// Finality of a transaction or block in which transaction is included in. For more info
 /// go to the [NEAR finality](https://docs.near.org/docs/concepts/transaction#finality) docs.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 #[non_exhaustive]
 pub enum Finality {
     /// Optimistic finality. The latest block recorded on the node that responded to our query

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -192,7 +192,7 @@ impl fmt::Debug for CryptoHash {
 
 impl fmt::Display for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&to_base58(&self.0), f)
+        fmt::Display::fmt(&to_base58(self.0), f)
     }
 }
 


### PR DESCRIPTION
Moves the HashMap key from `AccountId` to `PublicKey`, since we want to associate it based on per-access-key instead of per account

Also, added debug/clone impls for the types that were added in recent PRs