### PR TITLE
WIP: don't lose error context

### DIFF
--- a/workspaces/src/error/impls.rs
+++ b/workspaces/src/error/impls.rs
@@ -112,11 +112,7 @@ impl fmt::Display for Error {
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match &self.repr {
-            ErrorRepr::Custom { error, .. } => error.source(),
-            ErrorRepr::Full { error, .. } => error.source(),
-            _ => None,
-        }
+        self.repr.source()
     }
 }
 

--- a/workspaces/src/error/mod.rs
+++ b/workspaces/src/error/mod.rs
@@ -19,7 +19,7 @@ pub enum ErrorKind {
     #[error("Execution")]
     Execution,
     /// An error having to do with running sandbox.
-    #[error("Sandbox({0})")]
+    #[error("{0}")]
     Sandbox(#[from] SandboxErrorCode),
     /// An error from performing IO.
     #[error("IO")]
@@ -38,9 +38,10 @@ enum ErrorRepr {
         kind: ErrorKind,
         message: Cow<'static, str>,
     },
-    #[error("{error}")]
+    #[error("{kind}")]
     Custom {
         kind: ErrorKind,
+        #[source]
         error: Box<dyn std::error::Error + Send + Sync>,
     },
     #[error("{message}: {error}")]


### PR DESCRIPTION
This is more of a bug report than a PR, I don't plan to make this production ready :)

It seems we are loosing quite a bit of error context somewhere.

Before this PR:

```
λ cargo run --example nft
Error: No such file or directory (os error 2)
```

After this PR: 

```
λ cargo run --example nft
Error: Could not initialize sandbox node

Caused by:
    No such file or directory (os error 2)
```


Note that even improved output is quite suboptimal, as it doesn't tell _which_ file or directory is not found, but the roots of that are deep in the `sandbox-util` crate