### PR TITLE
chore: expose `view_chunk`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - [`view_*` asynchronous builders have been added which provides being able to query from a specific block hash or block height](https://github.com/near/workspaces-rs/pull/218)
 - [`{CallTransaction, Transaction}::transact_async` for performing transactions without directly having to wait for it complete it on chain](https://github.com/near/workspaces-rs/pull/222)
+- [`view_chunk` added for querying into chunk related info on the network.](https://github.com/near/workspaces-rs/pull/234)
+  - Adds `Chunk` and `ChunkHeader` type to reference specific chunk info.
 
 ### Changed
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -45,3 +45,7 @@ path = "src/fast_forward.rs"
 [[example]]
 name = "croncat"
 path = "src/croncat.rs"
+
+[[example]]
+name = "various_queries"
+path = "src/various_queries.rs"

--- a/examples/src/various_queries.rs
+++ b/examples/src/various_queries.rs
@@ -1,10 +1,14 @@
+use serde_json::json;
+
+/// This example will show various calls into viewing information from what's on the sandbox chain
+/// to what was on the chain prior to modifying state.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let worker = workspaces::sandbox().await?;
 
     // Fetch the latest block produced from the network.
     let block = worker.view_block().await?;
-    println!("Block: {block:?}");
+    println!("Latest Block: {block:#?}");
 
     // Fetch the block from the genesis point of the sandbox network. This is not necessarily
     // the genesis of every network since they can re-genesis at a higher block height.
@@ -13,7 +17,7 @@ async fn main() -> anyhow::Result<()> {
         .block_height(0)
         // can instead use .block_hash(CryptoHash) as well
         .await?;
-    println!("Sandbox Geneis Block: {genesis_block:?}");
+    println!("Sandbox Geneis Block: {genesis_block:#?}");
 
     // Reference the chunk via the block hash we queried for earlier:
     let shard_id = 0;
@@ -21,7 +25,72 @@ async fn main() -> anyhow::Result<()> {
         .view_chunk()
         .block_hash_and_shard(*block.hash(), shard_id)
         .await?;
-    println!("Chunk: {chunk:?}");
+    println!("Latest Chunk: {chunk:#?}");
+
+    let bob = worker.dev_create_account().await?;
+    println!("\nCreated bob's account with id {:?}", bob.id());
+
+    // Show all the access keys relating to bob:
+    let access_keys = bob.view_access_keys().await?;
+    println!("bob's access keys: {access_keys:?}");
+
+    let status_msg = worker
+        .dev_deploy(include_bytes!("../res/status_message.wasm"))
+        .await?;
+
+    // Let's have bob set the "Hello" message into the contract.
+    let outcome = bob
+        .call(status_msg.id(), "set_status")
+        .args_json(json!({
+            "message": "Hello"
+        }))
+        .transact()
+        .await?
+        .into_result()?;
+    println!(
+        "Bob burnt {} gas callling into `set_status('Hello')`",
+        outcome.total_gas_burnt
+    );
+
+    // let's get a reference point to the chain at it's current state, so we can reference it back later
+    // when we want older data from the chain.
+    let block = worker.view_block().await?;
+
+    // Override bob's message of "Hello" with "World".
+    let outcome = bob
+        .call(status_msg.id(), "set_status")
+        .args_json(json!({
+            "message": "World"
+        }))
+        .transact()
+        .await?
+        .into_result()?;
+    println!(
+        "Bob burnt {} gas callling into `set_status('World')`",
+        outcome.total_gas_burnt
+    );
+
+    // Then view that it indeed has changed:
+    let msg: String = status_msg
+        .view("get_status")
+        .args_json(json!({
+            "account_id": bob.id(),
+        }))
+        .await?
+        .json()?;
+    println!("Bob's status message: '{}'", msg);
+
+    // But since we have a reference point to before bob overrode his message, we can view the message
+    // from then as well, by giving the reference into the view function call:
+    let msg: String = status_msg
+        .view("get_status")
+        .args_json(json!({
+            "account_id": bob.id(),
+        }))
+        .block_hash(*block.hash())
+        .await?
+        .json()?;
+    println!("Bob's older status message: '{}'", msg);
 
     Ok(())
 }

--- a/examples/src/various_queries.rs
+++ b/examples/src/various_queries.rs
@@ -1,0 +1,27 @@
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox().await?;
+
+    // Fetch the latest block produced from the network.
+    let block = worker.view_block().await?;
+    println!("Block: {block:?}");
+
+    // Fetch the block from the genesis point of the sandbox network. This is not necessarily
+    // the genesis of every network since they can re-genesis at a higher block height.
+    let genesis_block = worker
+        .view_block()
+        .block_height(0)
+        // can instead use .block_hash(CryptoHash) as well
+        .await?;
+    println!("Sandbox Geneis Block: {genesis_block:?}");
+
+    // Reference the chunk via the block hash we queried for earlier:
+    let shard_id = 0;
+    let chunk = worker
+        .view_chunk()
+        .block_hash_and_shard(*block.hash(), shard_id)
+        .await?;
+    println!("Chunk: {chunk:?}");
+
+    Ok(())
+}

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -22,6 +22,7 @@ pub use network::variants::{DevNetwork, Network};
 pub use result::Result;
 pub use types::account::{Account, AccountDetails, Contract};
 pub use types::block::Block;
+pub use types::chunk::Chunk;
 pub use types::{AccessKey, AccountId, BlockHeight, CryptoHash, InMemorySigner};
 pub use worker::{
     betanet, mainnet, mainnet_archival, sandbox, testnet, testnet_archival, with_betanet,

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -242,11 +242,11 @@ impl<'a> Transaction<'a> {
 
     /// Send the transaction to the network to be processed. This will be done asynchronously
     /// without waiting for the transaction to complete. This returns us a [`TransactionStatus`]
-    /// for which we can call into [`status`] and/or [`wait`] to retrieve info about whether
-    /// the transaction has been completed or not.
+    /// for which we can call into [`status`] and/or `.await` to retrieve info about whether
+    /// the transaction has been completed or not. Note that `.await` will wait till completion
+    /// of the transaction.
     ///
     /// [`status`]: TransactionStatus::status
-    /// [`wait`]: TransactionStatus::wait
     pub async fn transact_async(self) -> Result<TransactionStatus<'a>> {
         send_batch_tx_async_and_retry(self.client, &self.signer, &self.receiver_id, self.actions?)
             .await
@@ -339,11 +339,11 @@ impl<'a> CallTransaction<'a> {
 
     /// Send the transaction to the network to be processed. This will be done asynchronously
     /// without waiting for the transaction to complete. This returns us a [`TransactionStatus`]
-    /// for which we can call into [`status`] and/or [`wait`] to retrieve info about whether
-    /// the transaction has been completed or not.
+    /// for which we can call into [`status`] and/or `.await` to retrieve info about whether
+    /// the transaction has been completed or not. Note that `.await` will wait till completion
+    /// of the transaction.
     ///
     /// [`status`]: TransactionStatus::status
-    /// [`wait`]: TransactionStatus::wait
     pub async fn transact_async(self) -> Result<TransactionStatus<'a>> {
         send_batch_tx_async_and_retry(
             self.worker.client(),

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -467,7 +467,6 @@ impl<'a> std::future::IntoFuture for QueryChunk<'a> {
                 }
             };
 
-            // let block_reference = self.chunk_ref.unwrap_or_else();
             let chunk_view = self
                 .client
                 .query(methods::chunk::RpcChunkRequest { chunk_reference })

--- a/workspaces/src/types/block.rs
+++ b/workspaces/src/types/block.rs
@@ -3,7 +3,7 @@ use near_primitives::views::{BlockHeaderView, BlockView};
 use crate::{BlockHeight, CryptoHash};
 
 /// Struct containing information on block coming from the network
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Block {
     header: BlockHeader,
 }
@@ -32,7 +32,7 @@ impl Block {
 
 /// The block header info. This is a non-exhaustive list of items that
 /// could be present in a block header. More can be added in the future.
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct BlockHeader {
     height: BlockHeight,
     epoch_id: CryptoHash,

--- a/workspaces/src/types/chunk.rs
+++ b/workspaces/src/types/chunk.rs
@@ -64,11 +64,6 @@ impl From<ChunkView> for Chunk {
 }
 
 impl Chunk {
-    /// The author's [`AccountId`] relating to the creation of this chunk.
-    pub fn author(&self) -> &AccountId {
-        &self.author
-    }
-
     /// The hash of the chunk itself.
     pub fn hash(&self) -> &CryptoHash {
         &self.header.chunk_hash

--- a/workspaces/src/types/chunk.rs
+++ b/workspaces/src/types/chunk.rs
@@ -1,0 +1,40 @@
+use near_primitives::views::ChunkView;
+
+use crate::types::ShardId;
+use crate::CryptoHash;
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct Chunk {
+    pub header: ChunkHeader,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub struct ChunkHeader {
+    pub chunk_hash: CryptoHash,
+    pub prev_block_hash: CryptoHash,
+    pub shard_id: ShardId,
+}
+
+impl From<ChunkView> for Chunk {
+    fn from(view: ChunkView) -> Self {
+        Self {
+            header: ChunkHeader {
+                chunk_hash: view.header.chunk_hash.into(),
+                prev_block_hash: view.header.prev_block_hash.into(),
+                shard_id: view.header.shard_id,
+            },
+        }
+    }
+}
+
+impl Chunk {
+    pub fn hash(&self) -> &CryptoHash {
+        &self.header.chunk_hash
+    }
+
+    pub fn shard_id(&self) -> ShardId {
+        self.header.shard_id
+    }
+}

--- a/workspaces/src/types/chunk.rs
+++ b/workspaces/src/types/chunk.rs
@@ -1,39 +1,80 @@
+use near_account_id::AccountId;
 use near_primitives::views::ChunkView;
 
-use crate::types::ShardId;
-use crate::CryptoHash;
+use crate::types::{Balance, Gas, ShardId};
+use crate::{BlockHeight, CryptoHash};
 
-#[derive(Debug, Clone, PartialEq)]
+// Chunk object associated to a chunk on chain. This provides info about what
+// current state of a chunk is like.
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct Chunk {
+    pub author: AccountId,
     pub header: ChunkHeader,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+/// The header belonging to a [`Chunk`]. This is a non-exhaustive list of
+/// members belonging to a Chunk, where newer fields can be added in the future.
+///
+/// NOTE: validator_proposals have been omitted for now. If you need it, submit a ticket to:
+/// https://github.com/near/workspaces-rs/issues
+#[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct ChunkHeader {
     pub chunk_hash: CryptoHash,
     pub prev_block_hash: CryptoHash,
+    pub height_created: BlockHeight,
+    pub height_included: BlockHeight,
     pub shard_id: ShardId,
+    pub gas_used: Gas,
+    pub gas_limit: Gas,
+    pub balance_burnt: Balance,
+
+    pub tx_root: CryptoHash,
+    pub outcome_root: CryptoHash,
+    pub prev_state_root: CryptoHash,
+    pub outgoing_receipts_root: CryptoHash,
+    pub encoded_merkle_root: CryptoHash,
+    pub encoded_length: u64,
 }
 
 impl From<ChunkView> for Chunk {
     fn from(view: ChunkView) -> Self {
         Self {
+            author: view.author,
             header: ChunkHeader {
                 chunk_hash: view.header.chunk_hash.into(),
                 prev_block_hash: view.header.prev_block_hash.into(),
+                height_created: view.header.height_created,
+                height_included: view.header.height_included,
                 shard_id: view.header.shard_id,
+                gas_used: view.header.gas_used,
+                gas_limit: view.header.gas_limit,
+                balance_burnt: view.header.balance_burnt,
+
+                tx_root: view.header.tx_root.into(),
+                outcome_root: view.header.outcome_root.into(),
+                prev_state_root: view.header.prev_state_root.into(),
+                outgoing_receipts_root: view.header.outgoing_receipts_root.into(),
+                encoded_merkle_root: view.header.encoded_merkle_root.into(),
+                encoded_length: view.header.encoded_length,
             },
         }
     }
 }
 
 impl Chunk {
+    /// The author's [`AccountId`] relating to the creation of this chunk.
+    pub fn author(&self) -> &AccountId {
+        &self.author
+    }
+
+    /// The hash of the chunk itself.
     pub fn hash(&self) -> &CryptoHash {
         &self.header.chunk_hash
     }
 
+    /// Which specific shard this chunk belongs to.
     pub fn shard_id(&self) -> ShardId {
         self.header.shard_id
     }

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod account;
 pub(crate) mod block;
+pub(crate) mod chunk;
 
 /// Types copied over from near_primitives since those APIs are not yet stable.
 /// and internal libraries like near-jsonrpc-client requires specific versions
@@ -16,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Error, ErrorKind};
 use crate::result::Result;
 
+pub use self::chunk::{Chunk, ChunkHeader};
+
 /// Nonce is a unit used to determine the order of transactions in the pool.
 pub type Nonce = u64;
 
@@ -29,6 +32,9 @@ pub type Balance = u128;
 
 /// Height of a specific block
 pub type BlockHeight = u64;
+
+/// Shard index, from 0 to NUM_SHARDS - 1.
+pub type ShardId = u64;
 
 fn from_base58(s: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     bs58::decode(s).into_vec().map_err(|err| err.into())
@@ -193,6 +199,12 @@ impl fmt::Debug for CryptoHash {
 impl fmt::Display for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&to_base58(self.0), f)
+    }
+}
+
+impl From<near_primitives::hash::CryptoHash> for CryptoHash {
+    fn from(hash: near_primitives::hash::CryptoHash) -> Self {
+        Self(hash.0)
     }
 }
 

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -5,8 +5,8 @@ use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
 use crate::rpc::patch::ImportContractTransaction;
 use crate::rpc::query::{
-    GasPrice, Query, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock, ViewCode,
-    ViewFunction, ViewState,
+    GasPrice, Query, QueryChunk, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock,
+    ViewCode, ViewFunction, ViewState,
 };
 use crate::types::{AccountId, Gas, InMemorySigner, PublicKey};
 use crate::worker::Worker;
@@ -101,10 +101,26 @@ where
         Query::view_state(self.client(), contract_id)
     }
 
-    /// View the block from the network. Supply additional parameters such as `block_height`
-    /// or `block_hash` to get the block.
+    /// View the block from the network. Supply additional parameters such as [`block_height`]
+    /// or [`block_hash`] to get the block.
+    ///
+    /// [`block_height`]: Query::block_height
+    /// [`block_hash`]: Query::block_hash
     pub fn view_block(&self) -> Query<'_, ViewBlock> {
         Query::new(self.client(), ViewBlock)
+    }
+
+    /// View the chunk from the network once awaited. Supply additional parameters such as
+    /// [`block_hash_and_shard`], [`block_height_and_shard`] or [`chunk_hash`] to get the
+    /// chunk at a specific reference point. If none of those are supplied, the default
+    /// reference point will be used, which will be the latest block_hash with a shard_id
+    /// of 0.
+    ///
+    /// [`block_hash_and_shard`]: QueryChunk::block_hash_and_shard
+    /// [`block_height_and_shard`]: QueryChunk::block_height_and_shard
+    /// [`chunk_hash`]: QueryChunk::chunk_hash
+    pub fn view_chunk(&self) -> QueryChunk<'_> {
+        QueryChunk::new(self.client())
     }
 
     /// Views the [`AccessKey`] of the account specified by [`AccountId`] associated with


### PR DESCRIPTION
This adds `worker.view_chunk` method for users to call into. Internally, uses `QueryChunk`, since `Query` is more for block reference related queries and nothing else uses `ChunkReference` when making queries.

Also adds a new `various_queries` example to showcase querying both chunk and block data, while being able to query for old contract state data as well.