### PR TITLE
fix: remove unused import of metadata

### DIFF
--- a/examples/simple-contract/Cargo.toml
+++ b/examples/simple-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.0.0-pre.7"
+near-sdk = "4.1.1"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "4.0.0-pre.7"
-near-contract-standards = "4.0.0-pre.7"
+near-sdk = "4.1.1"
+near-contract-standards = "4.1.1"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/status-message/src/lib.rs
+++ b/workspaces/tests/test-contracts/status-message/src/lib.rs
@@ -1,5 +1,5 @@
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
-use near_sdk::{env, log, metadata, near_bindgen, AccountId};
+use near_sdk::{env, log, near_bindgen, AccountId};
 use std::collections::HashMap;
 
 #[near_bindgen]


### PR DESCRIPTION
metadata was imported but not used previously, was removed in 4.1.