### PR TITLE
fix: Make call consistent with worker::view

### DIFF
--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -98,9 +98,9 @@ impl TopLevelAccountCreator for Sandbox {
             .create_account(&root_signer, &id, sk.public_key(), DEFAULT_DEPOSIT)
             .await?;
 
-        let signer = InMemorySigner::from_secret_key(id.clone(), sk);
+        let signer = InMemorySigner::from_secret_key(id, sk);
         Ok(Execution {
-            result: Account::new(id, signer, worker),
+            result: Account::new(signer, worker),
             details: ExecutionFinalResult::from_view(outcome),
         })
     }
@@ -124,9 +124,9 @@ impl TopLevelAccountCreator for Sandbox {
             )
             .await?;
 
-        let signer = InMemorySigner::from_secret_key(id.clone(), sk);
+        let signer = InMemorySigner::from_secret_key(id, sk);
         Ok(Execution {
-            result: Contract::new(id, signer, worker),
+            result: Contract::new(signer, worker),
             details: ExecutionFinalResult::from_view(outcome),
         })
     }

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -83,10 +83,10 @@ impl TopLevelAccountCreator for Testnet {
     ) -> Result<Execution<Account>> {
         let url = Url::parse(HELPER_URL).unwrap();
         tool::url_create_account(url, id.clone(), sk.public_key()).await?;
-        let signer = InMemorySigner::from_secret_key(id.clone(), sk);
+        let signer = InMemorySigner::from_secret_key(id, sk);
 
         Ok(Execution {
-            result: Account::new(id, signer, worker),
+            result: Account::new(signer, worker),
             details: ExecutionFinalResult {
                 // We technically have not burnt any gas ourselves since someone else paid to
                 // create the account for us in testnet when we used the Helper contract.

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -154,6 +154,6 @@ impl<'a, 'b> ImportContractTransaction<'a> {
             .await
             .map_err(|err| SandboxErrorCode::PatchStateFailure.custom(err))?;
 
-        Ok(Contract::new(account_id, signer, self.into_network))
+        Ok(Contract::new(signer, self.into_network))
     }
 }

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -46,12 +46,12 @@ where
     /// will be used to sign the transaction.
     ///
     /// [`signer`]: crate::types::InMemorySigner
-    pub fn call<'a>(
-        &'a self,
+    pub fn call(
+        &self,
         signer: &InMemorySigner,
         contract_id: &AccountId,
         function: &str,
-    ) -> CallTransaction<'a> {
+    ) -> CallTransaction<'_> {
         CallTransaction::new(
             self.client(),
             contract_id.to_owned(),

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -1,16 +1,16 @@
 use crate::network::{AllowDevAccountCreation, NetworkClient, NetworkInfo};
 use crate::network::{Info, Sandbox};
-use crate::operations::Function;
+use crate::operations::{CallTransaction, Function};
 use crate::result::{ExecutionFinalResult, Result};
-use crate::rpc::client::{Client, DEFAULT_CALL_DEPOSIT, DEFAULT_CALL_FN_GAS};
+use crate::rpc::client::Client;
 use crate::rpc::patch::ImportContractTransaction;
 use crate::rpc::query::{
     GasPrice, Query, QueryChunk, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock,
     ViewCode, ViewFunction, ViewState,
 };
-use crate::types::{AccountId, Gas, InMemorySigner, PublicKey};
+use crate::types::{AccountId, InMemorySigner, PublicKey};
 use crate::worker::Worker;
-use crate::{Account, Contract, Network};
+use crate::{Account, Network};
 
 use near_primitives::types::Balance;
 
@@ -41,31 +41,28 @@ where
         self.workspace.client()
     }
 
-    /// Call into a contract's change function.
-    pub async fn call(
-        &self,
-        contract: &Contract,
+    /// Call into a contract's change function. Returns a [`CallTransaction`] object
+    /// that we will make use to populate the rest of the call details. The [`signer`]
+    /// will be used to sign the transaction.
+    ///
+    /// [`signer`]: crate::types::InMemorySigner
+    pub fn call<'a>(
+        &'a self,
+        signer: &InMemorySigner,
+        contract_id: &AccountId,
         function: &str,
-        args: Vec<u8>,
-        gas: Option<Gas>,
-        deposit: Option<Balance>,
-    ) -> Result<ExecutionFinalResult> {
-        let outcome = self
-            .client()
-            .call(
-                contract.signer(),
-                contract.id(),
-                function.into(),
-                args,
-                gas.unwrap_or(DEFAULT_CALL_FN_GAS),
-                deposit.unwrap_or(DEFAULT_CALL_DEPOSIT),
-            )
-            .await?;
-
-        Ok(ExecutionFinalResult::from_view(outcome))
+    ) -> CallTransaction<'a> {
+        CallTransaction::new(
+            self.client(),
+            contract_id.to_owned(),
+            signer.clone(),
+            function,
+        )
     }
 
-    /// Call into a contract's view function.
+    /// Call into a contract's view function. Returns a [`Query`] which allows us
+    /// to specify further details like the arguments of the view call, or at what
+    /// point in the chain we want to view.
     pub fn view(&self, contract_id: &AccountId, function: &str) -> Query<'_, ViewFunction> {
         self.view_by_function(contract_id, Function::new(function))
     }
@@ -197,9 +194,8 @@ where
 
 impl Worker<Sandbox> {
     pub fn root_account(&self) -> Result<Account> {
-        let account_id = self.info().root_id.clone();
         let signer = self.workspace.root_signer()?;
-        Ok(Account::new(account_id, signer, self.clone().coerce()))
+        Ok(Account::new(signer, self.clone().coerce()))
     }
 
     /// Import a contract from the the given network, and return us a [`ImportContractTransaction`]


### PR DESCRIPTION
Since `Worker::view` got changed to be a builder, I noticed that `Worker::call` is no longer consistent with it. So best to make it also return a builder similar to `Account::call` as well. This should come in before [release/0.7.0](https://github.com/near/workspaces-rs/pull/244).

Also, exposed `{Account, Contract}::signer()` since that has been public and can be utilized with `Worker` related methods. Internally cleaned up the storage of `AccountId` in `Account` since `InMemorySigner` already holds the account id.