### PR TITLE
(ignore): RPC tx wait integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Build files
-/target
+**/target
 Cargo.lock
 
 # Code Editor related files

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -51,6 +51,8 @@ near-units = "0.2.0"
 near-sdk = "4.0.0"
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
+# TODO remove this if this PR ever comes in
+reqwest = { version = "0.11.12", features = ["json"], default-features = false }
 
 [features]
 default = ["install"]

--- a/workspaces/tests/test-contracts/promise-chain/Cargo.toml
+++ b/workspaces/tests/test-contracts/promise-chain/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "test-promise-chain"
+version = "0.0.0"
+authors = ["Near Inc <hello@nearprotocol.com>"]
+edition = "2018"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+near-sdk = "4.1.1"
+
+[profile.release]
+codegen-units = 1
+# Tell `rustc` to optimize for small code size.
+opt-level = "z"
+lto = true
+debug = false
+panic = "abort"
+overflow-checks = true
+
+[workspace]

--- a/workspaces/tests/test-contracts/promise-chain/src/lib.rs
+++ b/workspaces/tests/test-contracts/promise-chain/src/lib.rs
@@ -1,0 +1,28 @@
+use near_sdk::{env, log, near_bindgen, Promise};
+
+#[near_bindgen]
+pub struct Chained;
+
+#[near_bindgen]
+impl Chained {
+    /// Calls b and uses that as the transaction result. Schedules some irrelevant methods after.
+    /// Call chain looks like:
+    /// a -> b (execution result) -> c -> c
+    pub fn a() -> Promise {
+        Self::ext(env::current_account_id()).b()
+    }
+
+    #[private]
+    pub fn b() -> &'static str {
+        Self::ext(env::current_account_id())
+            .c()
+            .then(Self::ext(env::current_account_id()).c());
+        "Test string"
+    }
+
+    #[private]
+    pub fn c() -> &'static str{
+        log!("called c");
+        "some other"
+    }
+}

--- a/workspaces/tests/tx_async_wait.rs
+++ b/workspaces/tests/tx_async_wait.rs
@@ -1,18 +1,130 @@
 #![cfg(feature = "unstable")]
 
-#[tokio::test]
+use near_primitives::views::FinalExecutionOutcomeView;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum TxWaitType {
+    /// Waits until the transaction result value is executed and finalized.
+    /// Note: this does not wait on all execution results, only the tx return value.
+    ExecutionResult,
+    /// Waits until everything has executed and is final, including refund receipts.
+    Full,
+}
+
+async fn send_wait_req(
+    client: reqwest::Client,
+    rpc_addr: String,
+    params: impl serde::Serialize,
+) -> anyhow::Result<FinalExecutionOutcomeView> {
+    let req = near_jsonrpc_primitives::message::Message::request(
+        "EXPERIMENTAL_tx_wait".to_string(),
+        Some(serde_json::to_value(params)?),
+    );
+
+    let payload = serde_json::to_vec(&req).unwrap();
+
+    let response = client
+        .post(rpc_addr)
+        // .headers(headers.clone())
+        .body(payload)
+        .send()
+        .await?;
+
+    assert!(matches!(response.status(), reqwest::StatusCode::OK));
+
+    let res = serde_json::from_slice(&response.bytes().await?);
+    let response_message = near_jsonrpc_primitives::message::decoded_to_parsed(res).unwrap();
+    let near_jsonrpc_primitives::message::Message::Response(response) = response_message else {
+		return Err(anyhow::anyhow!("Expected response"));
+	};
+    Ok(serde_json::from_value(response.result.unwrap())?)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_async_wait_finality() -> anyhow::Result<()> {
     let worker = workspaces::sandbox().await?;
     let wasm = workspaces::compile_project("./tests/test-contracts/promise-chain").await?;
     let contract = worker.dev_deploy(&wasm).await?;
     let account = worker.dev_create_account().await?;
 
+    let now = std::time::Instant::now();
     let result = account
         .call(contract.id(), "a")
         .max_gas()
         .transact_async()
         .await?;
-    assert_eq!(result.await?.json::<String>()?, "Test string");
+
+    let sender_id = result.sender_id();
+    let tx_hash = near_primitives::hash::CryptoHash(result.hash().0);
+
+    let rpc_addr = format!("http://localhost:{}", worker.rpc_port());
+
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        reqwest::header::CONTENT_TYPE,
+        reqwest::header::HeaderValue::from_static("application/json"),
+    );
+
+    let client = reqwest::Client::builder()
+        .default_headers(headers.clone())
+        .build()?;
+
+    let req_fut = send_wait_req(
+        client.clone(),
+        rpc_addr.clone(),
+        (tx_hash, sender_id.clone(), "final", "full"),
+    );
+    let ff_handle = tokio::task::spawn(async move {
+        let res = req_fut.await.unwrap();
+        println!("final full: {}", now.elapsed().as_millis());
+        res
+    });
+
+    let req_fut = send_wait_req(
+        client.clone(),
+        rpc_addr.clone(),
+        (tx_hash, sender_id.clone(), "near-final", "execution_result"),
+    );
+    let dsf_handle = tokio::task::spawn(async move {
+        let res = req_fut.await.unwrap();
+        println!("ds execution: {}", now.elapsed().as_millis());
+        res
+    });
+
+    let req_fut = send_wait_req(
+        client.clone(),
+        rpc_addr.clone(),
+        (tx_hash, sender_id.clone(), "final", "execution_result"),
+    );
+    let ef_handle = tokio::task::spawn(async move {
+        let res = req_fut.await.unwrap();
+        println!("final execution: {}", now.elapsed().as_millis());
+        println!(
+            "ef_res: {:?}",
+            res.receipts_outcome
+                .iter()
+                .map(|r| r.outcome.status.clone())
+                .collect::<Vec<_>>()
+        );
+        res
+    });
+
+    let req_fut = send_wait_req(
+        client.clone(),
+        rpc_addr.clone(),
+        (tx_hash, sender_id.clone(), "optimistic", "execution_result"),
+    );
+    let oe_handle = tokio::task::spawn(async move {
+        let res = req_fut.await.unwrap();
+        println!("optimistic execution: {}", now.elapsed().as_millis());
+        res
+    });
+
+    println!("PRE WAIT: {}", now.elapsed().as_millis());
+    // FIXME finality doesn't have an effect on the times currently. Everything is full finality
+    futures::future::join_all([oe_handle, ef_handle, ff_handle, dsf_handle]).await;
 
     Ok(())
 }

--- a/workspaces/tests/tx_async_wait.rs
+++ b/workspaces/tests/tx_async_wait.rs
@@ -1,0 +1,18 @@
+#![cfg(feature = "unstable")]
+
+#[tokio::test]
+async fn test_async_wait_finality() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox().await?;
+    let wasm = workspaces::compile_project("./tests/test-contracts/promise-chain").await?;
+    let contract = worker.dev_deploy(&wasm).await?;
+    let account = worker.dev_create_account().await?;
+
+    let result = account
+        .call(contract.id(), "a")
+        .max_gas()
+        .transact_async()
+        .await?;
+    assert_eq!(result.await?.json::<String>()?, "Test string");
+
+    Ok(())
+}


### PR DESCRIPTION
Just opening for visibility and to link to https://github.com/near/nearcore/pull/8138

This likely won't come into workspaces, just using as an integration test, but there could be a good reason for it in the future.

This can remove the need to poll for the tx result externally (in https://github.com/near/workspaces-rs/blob/2a325734e7be98c5b7d2f92b3e902556fb99bd3d/workspaces/src/operations.rs#L494-L501) and leave it up to the RPC to wait on the TX.

The test is hacky where RPC logic is manually done because I couldn't figure out a way to override the mess of dependencies of the RPC and types cleanly