### PR TITLE
chore: Added destination account-id for `import_contract` call

### DIFF
--- a/workspaces/src/error/impls.rs
+++ b/workspaces/src/error/impls.rs
@@ -6,14 +6,6 @@ use crate::result::ExecutionFailure;
 use super::{Error, ErrorKind, ErrorRepr, RpcErrorCode, SandboxErrorCode};
 
 impl ErrorKind {
-    pub(crate) fn full<E, T>(self, msg: T, error: E) -> Error
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync>>,
-        T: Into<Cow<'static, str>>,
-    {
-        Error::full(self, msg, error)
-    }
-
     pub(crate) fn custom<E>(self, error: E) -> Error
     where
         E: Into<Box<dyn std::error::Error + Send + Sync>>,

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -96,11 +96,11 @@ impl<'a> ImportContractTransaction<'a> {
     /// Process the transaction, and return the result of the execution.
     pub async fn transact(self) -> crate::result::Result<Contract> {
         let from_account_id = self.account_id;
-        let into_account_id = self.into_account_id.as_ref().unwrap_or(&from_account_id);
+        let into_account_id = self.into_account_id.as_ref().unwrap_or(from_account_id);
 
         let sk = SecretKey::from_seed(KeyType::ED25519, DEV_ACCOUNT_SEED);
         let pk = sk.public_key();
-        let signer = InMemorySigner::from_secret_key(from_account_id.clone(), sk);
+        let signer = InMemorySigner::from_secret_key(into_account_id.clone(), sk);
         let block_ref = self.block_ref.unwrap_or_else(BlockReference::latest);
 
         let mut account_view = self
@@ -128,7 +128,7 @@ impl<'a> ImportContractTransaction<'a> {
         if account_view.code_hash() != near_primitives::hash::CryptoHash::default() {
             let code = self
                 .from_network
-                .view_code(&from_account_id)
+                .view_code(from_account_id)
                 .block_reference(block_ref.clone())
                 .await?;
             records.push(StateRecord::Contract {
@@ -140,7 +140,7 @@ impl<'a> ImportContractTransaction<'a> {
         if self.import_data {
             records.extend(
                 self.from_network
-                    .view_state(&from_account_id)
+                    .view_state(from_account_id)
                     .block_reference(block_ref)
                     .await?
                     .into_iter()


### PR DESCRIPTION
Someone might want to set a different account-id for the imported contract than the original one. For example, let's say a user wants to import a contract multiple times into different accounts to test various states of them in parallel in the same sandbox. That isn't possible right now, so this PR should remedy that.

Sample usage:
```rust
worker.import_contract("contract.id".parse()?)
    .dest_account_id("other.id".parse()?)
    .transact()
    .await?;
```