### PR TITLE
feat: Worker::patch to patch account, keys, code, and state in a generic builder

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -22,6 +22,7 @@ hex = "0.4.2"
 portpicker = "0.1.1"
 rand = "0.8.4"
 reqwest = { version = "0.11", features = ["json"] }
+sha2 = "0.10"
 serde = "1.0"
 serde_json = "1.0"
 json-patch = "0.2"

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -130,7 +130,7 @@ impl<'a> ImportContractTransaction<'a> {
         if self.import_data {
             let states = self
                 .from_network
-                .view_state(&from_account_id)
+                .view_state(from_account_id)
                 .block_reference(block_ref)
                 .await?;
 
@@ -204,7 +204,7 @@ impl PatchTransaction {
     /// contained in sandbox with a list of access keys we specify.
     ///
     /// Similar to [`PatchTransaction::access_key`], but allows us to specify multiple access keys
-    pub fn access_keys<'b, 'c, I>(mut self, access_keys: I) -> Self
+    pub fn access_keys<I>(mut self, access_keys: I) -> Self
     where
         I: IntoIterator<Item = (PublicKey, AccessKey)>,
     {

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -333,6 +333,36 @@ pub struct AccountDetails {
 }
 
 impl AccountDetails {
+    pub fn new() -> Self {
+        Self {
+            balance: 0,
+            locked: 0,
+            code_hash: CryptoHash::default(),
+            storage_usage: 0,
+            storage_paid_at: 0,
+        }
+    }
+
+    pub fn balance(mut self, balance: Balance) -> Self {
+        self.balance = balance;
+        self
+    }
+
+    pub fn locked(mut self, locked: Balance) -> Self {
+        self.locked = locked;
+        self
+    }
+
+    pub fn code_hash(mut self, code_hash: CryptoHash) -> Self {
+        self.code_hash = code_hash;
+        self
+    }
+
+    pub fn storage_usage(mut self, storage_usage: u64) -> Self {
+        self.storage_usage = storage_usage;
+        self
+    }
+
     pub(crate) fn into_near_account(self) -> near_primitives::account::Account {
         AccountView {
             amount: self.balance,

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -364,15 +364,12 @@ impl AccountDetails {
     }
 
     pub(crate) fn into_near_account(self) -> near_primitives::account::Account {
-        AccountView {
-            amount: self.balance,
-            locked: self.locked,
-            // unwrap guranteed to succeed unless CryptoHash impls have changed in near_primitives.
-            code_hash: near_primitives::hash::CryptoHash(self.code_hash.0),
-            storage_usage: self.storage_usage,
-            storage_paid_at: self.storage_paid_at,
-        }
-        .into()
+        near_primitives::account::Account::new(
+            self.balance,
+            self.locked,
+            near_primitives::hash::CryptoHash(self.code_hash.0),
+            self.storage_usage,
+        )
     }
 }
 

--- a/workspaces/src/types/account.rs
+++ b/workspaces/src/types/account.rs
@@ -373,6 +373,12 @@ impl AccountDetails {
     }
 }
 
+impl Default for AccountDetails {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl From<AccountView> for AccountDetails {
     fn from(account: AccountView) -> Self {
         Self {

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -13,6 +13,7 @@ pub use near_account_id::AccountId;
 use near_primitives::logging::pretty_hash;
 use near_primitives::serialize::to_base58;
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
 
 use crate::error::{Error, ErrorKind};
 use crate::result::Result;
@@ -153,6 +154,13 @@ impl InMemorySigner {
 /// CryptoHash is type for storing the hash of a specific block.
 #[derive(Copy, Clone, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct CryptoHash(pub [u8; 32]);
+
+impl CryptoHash {
+    pub(crate) fn hash_bytes(bytes: &[u8]) -> Self {
+        let hash = sha2::Sha256::digest(bytes).into();
+        Self(hash)
+    }
+}
 
 impl std::str::FromStr for CryptoHash {
     type Err = Error;

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -218,7 +218,7 @@ impl Worker<Sandbox> {
     /// a [`PatchTransaction`] that will allow us to patch access keys, code, and contract state.
     /// This is similar to functions like [`Account::batch`] where we can perform multiple actions
     /// in one transaction.
-    pub fn patch<'a>(&'a self, account_id: &AccountId) -> PatchTransaction {
+    pub fn patch(&self, account_id: &AccountId) -> PatchTransaction {
         PatchTransaction::new(self, account_id.clone())
     }
 

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -3,7 +3,7 @@ use crate::network::{Info, Sandbox};
 use crate::operations::{CallTransaction, Function};
 use crate::result::{ExecutionFinalResult, Result};
 use crate::rpc::client::Client;
-use crate::rpc::patch::ImportContractTransaction;
+use crate::rpc::patch::{ImportContractTransaction, PatchTransaction};
 use crate::rpc::query::{
     GasPrice, Query, QueryChunk, ViewAccessKey, ViewAccessKeyList, ViewAccount, ViewBlock,
     ViewCode, ViewFunction, ViewState,
@@ -214,9 +214,17 @@ impl Worker<Sandbox> {
         ImportContractTransaction::new(id, worker.clone().coerce(), self.clone().coerce())
     }
 
-    /// Patch state into the sandbox network, given a key and value. This will allow us to set
-    /// state that we have acquired in some manner. This allows us to test random cases that
-    /// are hard to come up naturally as state evolves.
+    /// Start patching the state of the account specified by the [`AccountId`]. This will create
+    /// a [`PatchTransaction`] that will allow us to patch access keys, code, and contract state.
+    /// This is similar to functions like [`Account::batch`] where we can perform multiple actions
+    /// in one transaction.
+    pub fn patch<'a>(&'a self, account_id: &AccountId) -> PatchTransaction {
+        PatchTransaction::new(self, account_id.clone())
+    }
+
+    /// Patch state into the sandbox network, given a prefix key and value. This will allow us
+    /// to set contract state that we have acquired in some manner, where we are able to test
+    /// random cases that are hard to come up naturally as state evolves.
     pub async fn patch_state(
         &self,
         contract_id: &AccountId,

--- a/workspaces/src/worker/impls.rs
+++ b/workspaces/src/worker/impls.rs
@@ -211,7 +211,7 @@ impl Worker<Sandbox> {
         id: &'a AccountId,
         worker: &Worker<impl Network + 'static>,
     ) -> ImportContractTransaction<'a> {
-        ImportContractTransaction::new(id, worker.clone().coerce(), self.clone().coerce())
+        ImportContractTransaction::new(id, worker.clone().coerce(), self.clone())
     }
 
     /// Start patching the state of the account specified by the [`AccountId`]. This will create

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -5,9 +5,8 @@ use borsh::{self, BorshDeserialize, BorshSerialize};
 use serde_json::json;
 use test_log::test;
 
-use workspaces::rpc::patch::AccountUpdate;
 use workspaces::types::{KeyType, SecretKey};
-use workspaces::{AccessKey, AccountId, Contract, DevNetwork, Worker};
+use workspaces::{AccessKey, AccountDetails, AccountId, Contract, DevNetwork, Worker};
 
 const STATUS_MSG_WASM_FILEPATH: &str = "../examples/res/status_message.wasm";
 
@@ -74,7 +73,7 @@ async fn test_patch_state() -> anyhow::Result<()> {
     });
 
     worker
-        .patch_state(&contract_id, "STATE".as_bytes(), &status_msg.try_to_vec()?)
+        .patch_state(&contract_id, b"STATE", &status_msg.try_to_vec()?)
         .await?;
 
     let status: String = worker
@@ -131,12 +130,13 @@ async fn test_patch_full() -> anyhow::Result<()> {
     // Equivalent to worker.import_contract()
     worker
         .patch(&bob_id)
-        .account(AccountUpdate {
-            balance: near_units::parse_near!("100 N"),
-            locked: status_msg_acc.locked,
-            code_hash: status_msg_acc.code_hash,
-            storage_usage: status_msg_acc.storage_usage,
-        })
+        .account(
+            AccountDetails::new()
+                .balance(near_units::parse_near!("100 N"))
+                .locked(status_msg_acc.locked)
+                .code_hash(status_msg_acc.code_hash)
+                .storage_usage(status_msg_acc.storage_usage),
+        )
         .access_key(sk.public_key(), AccessKey::full_access())
         .code(&status_msg_code)
         .state(b"STATE", &status_msg.try_to_vec()?)

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -147,7 +147,7 @@ async fn test_patch_full() -> anyhow::Result<()> {
     let msg: String = bob_status_msg_acc
         .view("get_status")
         .args_json(json!({
-           "account_id": contract_id,
+            "account_id": contract_id,
         }))
         .await?
         .json()?;

--- a/workspaces/tests/patch_state.rs
+++ b/workspaces/tests/patch_state.rs
@@ -4,7 +4,10 @@
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use serde_json::json;
 use test_log::test;
-use workspaces::{AccountId, DevNetwork, Worker};
+use workspaces::{
+    types::{KeyType, SecretKey},
+    AccessKey, Account, AccountDetails, AccountId, DevNetwork, Worker,
+};
 
 const STATUS_MSG_WASM_FILEPATH: &str = "../examples/res/status_message.wasm";
 
@@ -83,6 +86,60 @@ async fn test_patch_state() -> anyhow::Result<()> {
         .json()?;
 
     assert_eq!(status, "hello world".to_string());
+
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_patch() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox().await?;
+    let (contract_id, mut status_msg) = view_status_state(worker.clone()).await?;
+    status_msg.records.push(Record {
+        k: "alice.near".to_string(),
+        v: "hello world".to_string(),
+    });
+
+    worker
+        .patch(&contract_id)
+        .state(b"STATE", &status_msg.try_to_vec()?)
+        .transact()
+        .await?;
+
+    let status: String = worker
+        .view(&contract_id, "get_status")
+        .args_json(json!({
+            "account_id": "alice.near",
+        }))
+        .await?
+        .json()?;
+
+    assert_eq!(status, "hello world".to_string());
+
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_patch_keys() -> anyhow::Result<()> {
+    let worker = workspaces::sandbox().await?;
+    let (contract_id, mut status_msg) = view_status_state(worker.clone()).await?;
+
+    let sk = SecretKey::from_seed(KeyType::ED25519, "bob's test key");
+    let bob = "bob.test.near".parse()?;
+    let bob = Account::from_secret_key(bob, sk, &worker);
+
+    let code_hash = worker.view_account(&contract_id).await?.code_hash;
+
+    worker
+        .patch(bob.id())
+        // .account(AccountDetails {
+        //     balance: near_units::parse_near!("100 N"),
+        //     locked: 0,
+        //     code_hash,
+        //     storage_usage: 100000,
+        // })
+        .access_key(bob.secret_key().public_key(), AccessKey::full_access())
+        .transact()
+        .await?;
 
     Ok(())
 }


### PR DESCRIPTION
This adds the `Worker::patch` builder described in https://github.com/near/workspaces-rs/issues/250. With it, we can now call into patching account details, keys, code, and state all in one place.

Example:

```rust

    worker
        .patch(&maybe_existing_account_id)
        .account(
            AccountDetails::new()
                .balance(near_units::parse_near!("100 N"))
                .locked(0)
                .storage_usage(100)
        )
        .access_key(public_key, AccessKey::full_access())
        .code(BYTES)
        .state(b"STATE", state_bytes)
        .transact()
        .await?;
```