### PR TITLE
chore: Import some functions over from near_crypto for PublicKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - [Import a couple functions over from near_crypto for PublicKey](https://github.com/near/workspaces-rs/pull/265)
-  - Impl `Ord`, `PartialOrd`, `Hash`, `BorshSerialize`, `BorshDeserialize`, `Display`, `FromStr`, `TryFrom<&[u8]>`, and `Into<Vec<u8>>` for `PublicKey`
+  - Impl `Ord`, `PartialOrd`, `Hash`, `BorshSerialize`, `BorshDeserialize`, `Display`, and `FromStr` for `PublicKey`
   - Added `PublicKey::{empty, len, key_data}`
   - Impl `Display` for `SecretKey`.
   - more docs were added to both `SecretKey` and `PublicKey`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- [Import a couple functions over from near_crypto for PublicKey](https://github.com/near/workspaces-rs/pull/265)
+  - Impl `Ord`, `PartialOrd`, `Hash`, `BorshSerialize`, `BorshDeserialize`, `Display`, `FromStr` for `PublicKey`
+  - Added `PublicKey::{empty, len, key_data}`
+  - Impl `Display` for `SecretKey`.
+  - more docs were added to both `SecretKey` and `PublicKey`.
+
 ### Changed
 
 - [`Transaction::transact_async` no longer has a lifetime parameter to make it easier to use](https://github.com/near/workspaces-rs/pull/249)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Added
 
 - [Import a couple functions over from near_crypto for PublicKey](https://github.com/near/workspaces-rs/pull/265)
-  - Impl `Ord`, `PartialOrd`, `Hash`, `BorshSerialize`, `BorshDeserialize`, `Display`, `FromStr` for `PublicKey`
+  - Impl `Ord`, `PartialOrd`, `Hash`, `BorshSerialize`, `BorshDeserialize`, `Display`, `FromStr`, `TryFrom<&[u8]>`, and `Into<Vec<u8>>` for `PublicKey`
   - Added `PublicKey::{empty, len, key_data}`
   - Impl `Display` for `SecretKey`.
   - more docs were added to both `SecretKey` and `PublicKey`.
+  - Impl `Display`, `FromStr`, `TryFrom<u8>` for `KeyType`.
 
 ### Changed
 

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -90,8 +90,10 @@ impl From<PublicKey> for near_crypto::PublicKey {
 )]
 pub struct PublicKey(pub(crate) near_crypto::PublicKey);
 
+#[allow(clippy::len_without_is_empty)] // PublicKey is guaranteed to never be empty due to KeyType restrictions.
 impl PublicKey {
-    /// Create an empty `PublicKey` with the given [`KeyType`].
+    /// Create an empty `PublicKey` with the given [`KeyType`]. This is a zero-ed out public key with the
+    /// length of the bytes determined by the associated key type.
     pub fn empty(key_type: KeyType) -> Self {
         Self(near_crypto::PublicKey::empty(key_type.into_near_keytype()))
     }

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -164,25 +164,6 @@ impl FromStr for PublicKey {
     }
 }
 
-impl From<PublicKey> for Vec<u8> {
-    fn from(pk: PublicKey) -> Vec<u8> {
-        let mut data = vec![pk.key_type() as u8];
-        data.extend(pk.key_data());
-        data
-    }
-}
-
-impl TryFrom<&[u8]> for PublicKey {
-    type Error = Error;
-
-    fn try_from(data: &[u8]) -> Result<Self, Self::Error> {
-        // Expected format:
-        // 1st byte: key type
-        // consecutive butes: key data
-        BorshDeserialize::try_from_slice(data).map_err(|e| ErrorKind::DataConversion.custom(e))
-    }
-}
-
 /// Secret key of an account on chain. Usually created along with a [`PublicKey`]
 /// to form a keypair associated to the account. To generate a new keypair, use
 /// one of the creation methods found here, such as [`SecretKey::from_seed`]

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -1,14 +1,17 @@
+//! Types used in the workspaces crate. A lot of these are types are copied over from near_primitives
+//! since those APIs are not yet stable. Once they are, we can directly reference them here, so no
+//! changes on the library consumer side is needed. Just keep using these types defined here as-is.
+
 pub(crate) mod account;
 pub(crate) mod block;
 pub(crate) mod chunk;
 
-/// Types copied over from near_primitives since those APIs are not yet stable.
-/// and internal libraries like near-jsonrpc-client requires specific versions
-/// of these types which shouldn't be exposed either.
 use std::convert::TryFrom;
-use std::fmt;
+use std::fmt::{self, Debug, Display};
 use std::path::Path;
+use std::str::FromStr;
 
+use borsh::{BorshDeserialize, BorshSerialize};
 pub use near_account_id::AccountId;
 use near_primitives::logging::pretty_hash;
 use near_primitives::serialize::to_base58;
@@ -72,12 +75,60 @@ impl From<PublicKey> for near_crypto::PublicKey {
 
 /// Public key of an account on chain. Usually created along with a [`SecretKey`]
 /// to form a keypair associated to the account.
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Debug,
+    Clone,
+    Hash,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
 pub struct PublicKey(pub(crate) near_crypto::PublicKey);
 
 impl PublicKey {
+    /// Create an empty `PublicKey` with the given [`KeyType`].
+    pub fn empty(key_type: KeyType) -> Self {
+        Self(near_crypto::PublicKey::empty(key_type.into_near_keytype()))
+    }
+
+    /// Get the number of bytes this key uses. This will differ depending on the [`KeyType`]. i.e. for
+    /// ED25519 keys, this will return 32 + 1, while for SECP256K1 keys, this will return 64 + 1. The +1
+    /// is used to store the key type, and will appear at the start of the serialized key.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Get the [`KeyType`] of the public key.
     pub fn key_type(&self) -> KeyType {
         KeyType::from_near_keytype(self.0.key_type())
+    }
+
+    /// Get the key data of the public key. This is serialized bytes of the public key. This will not
+    /// include the key type, and will only contain the raw key data.
+    pub fn key_data(&self) -> &[u8] {
+        self.0.key_data()
+    }
+}
+
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for PublicKey {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let pk = near_crypto::PublicKey::from_str(value)
+            .map_err(|e| ErrorKind::DataConversion.custom(e))?;
+
+        Ok(Self(pk))
     }
 }
 
@@ -88,26 +139,37 @@ impl PublicKey {
 pub struct SecretKey(pub(crate) near_crypto::SecretKey);
 
 impl SecretKey {
+    /// Get the [`KeyType`] of the secret key.
     pub fn key_type(&self) -> KeyType {
         KeyType::from_near_keytype(self.0.key_type())
     }
 
+    /// Get the [`PublicKey`] associated to this secret key.
     pub fn public_key(&self) -> PublicKey {
         PublicKey(self.0.public_key())
     }
 
+    /// Generate a new secret key provided the [`KeyType`] and seed.
     pub fn from_seed(key_type: KeyType, seed: &str) -> Self {
         let key_type = key_type.into_near_keytype();
         Self(near_crypto::SecretKey::from_seed(key_type, seed))
     }
 
+    /// Generate a new secret key provided the [`KeyType`]. This will use OS provided entropy
+    /// to generate the key.
     pub fn from_random(key_type: KeyType) -> Self {
         let key_type = key_type.into_near_keytype();
         Self(near_crypto::SecretKey::from_random(key_type))
     }
 }
 
-impl std::str::FromStr for SecretKey {
+impl Display for SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl FromStr for SecretKey {
     type Err = Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
@@ -154,7 +216,7 @@ impl InMemorySigner {
 #[derive(Copy, Clone, Default, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct CryptoHash(pub [u8; 32]);
 
-impl std::str::FromStr for CryptoHash {
+impl FromStr for CryptoHash {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -190,15 +252,15 @@ impl TryFrom<Vec<u8>> for CryptoHash {
     }
 }
 
-impl fmt::Debug for CryptoHash {
+impl Debug for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", pretty_hash(&self.to_string()))
     }
 }
 
-impl fmt::Display for CryptoHash {
+impl Display for CryptoHash {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&to_base58(self.0), f)
+        Display::fmt(&to_base58(self.0), f)
     }
 }
 

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -42,7 +42,7 @@ fn test_keypair_secp256k1() -> anyhow::Result<()> {
 
 #[test]
 fn test_borsh_on_pubkey() -> anyhow::Result<()> {
-    for key_type in &[KeyType::ED25519, KeyType::SECP256K1] {
+    for key_type in [KeyType::ED25519, KeyType::SECP256K1] {
         let sk = SecretKey::from_seed(key_type, "test");
         let pk = sk.public_key();
         let bytes = pk.try_to_vec()?;

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -54,35 +54,14 @@ fn test_pubkey_serialization() -> anyhow::Result<()> {
 
 #[test]
 fn test_pubkey_borsh_format_change() -> anyhow::Result<()> {
-    // Original struct to reference Borsh serialization from
-    struct PublicKeyRef(Vec<u8>);
-    impl BorshSerialize for PublicKeyRef {
-        fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-            writer.write_all(self.0.as_slice())
-        }
-    }
-    impl BorshDeserialize for PublicKeyRef {
-        fn deserialize(buf: &mut &[u8]) -> std::io::Result<Self> {
-            Ok(PublicKeyRef(buf.to_vec()))
-        }
-    }
-
     let mut data = vec![KeyType::ED25519 as u8];
     data.extend(bs58::decode("6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp").into_vec()?);
 
-    // Test internal serialization of Vec<u8> is the same:
-    let old_key = PublicKeyRef(data.clone());
-    let old_encoded_key = old_key.try_to_vec()?;
-    let new_key = PublicKey::try_from_slice(data.as_slice())?;
-    let new_encoded_key = new_key.try_to_vec()?;
-    assert_eq!(new_encoded_key, old_encoded_key);
+    let pk = PublicKey::try_from_slice(data.as_slice())?;
     assert_eq!(
-        new_encoded_key,
+        pk.try_to_vec()?,
         bs58::decode("16E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp").into_vec()?
     );
-
-    let decoded_key = PublicKey::try_from_slice(&new_encoded_key)?;
-    assert_eq!(decoded_key, new_key);
 
     Ok(())
 }

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -42,7 +42,7 @@ fn test_keypair_secp256k1() -> anyhow::Result<()> {
 
 #[test]
 fn test_borsh_on_pubkey() -> anyhow::Result<()> {
-    for key_type in vec![KeyType::ED25519, KeyType::SECP256K1] {
+    for key_type in &[KeyType::ED25519, KeyType::SECP256K1] {
         let sk = SecretKey::from_seed(key_type, "test");
         let pk = sk.public_key();
         let bytes = pk.try_to_vec()?;

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -1,4 +1,3 @@
-use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -46,10 +45,6 @@ fn test_pubkey_serialization() -> anyhow::Result<()> {
         // Borsh Deserialization should equate to the original public key:
         assert_eq!(PublicKey::try_from_slice(&bytes)?, pk);
 
-        // [key_type, key_data...] should equate to the original public key:
-        let bytes: Vec<u8> = pk.clone().into();
-        assert_eq!(PublicKey::try_from(bytes.as_slice())?, pk);
-
         // invalid public key should error out on deserialization:
         assert!(PublicKey::try_from_slice(&[0]).is_err());
     }
@@ -78,7 +73,7 @@ fn test_pubkey_borsh_format_change() -> anyhow::Result<()> {
     // Test internal serialization of Vec<u8> is the same:
     let old_key = PublicKeyRef(data.clone());
     let old_encoded_key = old_key.try_to_vec()?;
-    let new_key: PublicKey = data.as_slice().try_into()?;
+    let new_key = PublicKey::try_from_slice(data.as_slice())?;
     let new_encoded_key = new_key.try_to_vec()?;
     assert_eq!(new_encoded_key, old_encoded_key);
     assert_eq!(


### PR DESCRIPTION
This just adds a couple convenience methods over from `near_crypto` crate. This was originally requested with just `Hash` impl in https://github.com/near/workspaces-rs/issues/263, but decided to import a couple more functions as they are convenient to have if people are managing public keys with workspaces