### PR TITLE
Run `neard` on `localhost` instead of `0.0.0.0` to prevent firewall popups on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 
 ### Fixed
 
+- [Run `neard` on `localhost` instead of `0.0.0.0` to prevent firewall popups on MacOS](https://github.com/near/workspaces-rs/issues/276)
+
 ## [0.7.0]
 
 ### Added

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -20,7 +20,6 @@ cargo-near = "0.3.1"
 chrono = "0.4.19"
 fs2 = "0.4"
 hex = "0.4.2"
-portpicker = "0.1.1"
 rand = "0.8.4"
 reqwest = { version = "0.11", features = ["json"] }
 serde = "1.0"

--- a/workspaces/src/lib.rs
+++ b/workspaces/src/lib.rs
@@ -18,6 +18,7 @@ pub mod result;
 pub mod rpc;
 pub mod types;
 
+pub use network::pick_unused_port;
 pub use network::variants::{DevNetwork, Network};
 pub use result::Result;
 pub use types::account::{Account, AccountDetails, Contract};

--- a/workspaces/src/network/mod.rs
+++ b/workspaces/src/network/mod.rs
@@ -20,7 +20,7 @@ pub use self::betanet::Betanet;
 pub use self::info::Info;
 pub use self::mainnet::Mainnet;
 pub use self::sandbox::Sandbox;
-pub use self::server::ValidatorKey;
+pub use self::server::{pick_unused_port, ValidatorKey};
 pub use self::testnet::Testnet;
 pub use self::variants::{
     AllowDevAccountCreation, NetworkClient, NetworkInfo, TopLevelAccountCreator,

--- a/workspaces/tests/deploy.rs
+++ b/workspaces/tests/deploy.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use test_log::test;
 
 use workspaces::network::{Sandbox, ValidatorKey};
-use workspaces::Worker;
+use workspaces::{pick_unused_port, Worker};
 
 const NFT_WASM_FILEPATH: &str = "../examples/res/non_fungible_token.wasm";
 const EXPECTED_NFT_METADATA: &str = r#"{
@@ -59,10 +59,8 @@ async fn test_dev_deploy() -> anyhow::Result<()> {
 
 #[test(tokio::test)]
 async fn test_manually_spawned_deploy() -> anyhow::Result<()> {
-    let rpc_port =
-        portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free ports"))?;
-    let net_port =
-        portpicker::pick_unused_port().ok_or_else(|| anyhow::anyhow!("no free ports"))?;
+    let rpc_port = pick_unused_port().await?;
+    let net_port = pick_unused_port().await?;
     let mut home_dir = std::env::temp_dir();
     home_dir.push(format!("test-sandbox-{}", rpc_port));
 


### PR DESCRIPTION
This PR fixes the problem where users were getting firewall popups when running integration tests on MacOS as described in #276.

It turns out this had two causes:

1. `neard` was running on `0.0.0.0` instead of `localhost`.
2. The [`portpicker`](https://github.com/Dentosal/portpicker-rs) library used to acquire free random ports was testing ports by binding to `0.0.0.0`.

This PR fixes both causes. 

The PR changes how `neard` is ran by using the more verbose `run_with_options` where we can specify CLI arguments to `neard`. We use this to specify the IP address as localhost. Previously only the port numbers were specified and `neard` defaulted to running on `0.0.0.0`.

This PR also removes the `portpicker` library and provides a simple function to pick random port numbers with the OS feature where port number 0 is replaced by the OS with a random unused port. I initially considered contributing a fix to the `portpicker` library, but it seems unmaintained, so I thought it was a better choice to remove it from dependencies.

There are two differences between the implementation in the PR and the `portpicker` library:

1. The `portpicker` library also checks if the port returned by the OS is a valid UDP port. The implementation in this PR forgoes that check as I think we only need TCP ports for `neard`.
2. The `portpicker` library tries to acquire a random port by testing random numbers before falling back to requesting a port with port 0 from the OS. It's unclear why it does this. It might be a mechanism in case the OS doesn't support requesting random ports with port 0. All modern UNIX operating systems and Windows should support this, so I don't think we need such a fallback mechanism, but let me know if we do.
