### PR TITLE
feat: ExecutionOutcome.status should be public

### DIFF
--- a/workspaces/src/result.rs
+++ b/workspaces/src/result.rs
@@ -408,7 +408,7 @@ pub struct ExecutionOutcome {
     /// for receipt this is receiver_id.
     pub executor_id: AccountId,
     /// Execution status. Contains the result in case of successful execution.
-    pub(crate) status: ExecutionStatusView,
+    pub status: ExecutionStatusView,
 }
 
 impl ExecutionOutcome {


### PR DESCRIPTION
Today, the only way to check the transaction error content is to serialize it with JSON or format it with default display formatter. 
Moreover it's hard to check an error in a particular receipt.
Example: https://github.com/near-ndc/voting-v1/blob/8f1c14a/elections/tests/iah.rs#L169


Potential workaround would be to make `Error.repr` public. But the flow will be even more complicated:
```
    let failures = res.receipt_failures();
    for f in failures {
        let err = f.into_result().err().unwrap();
        match err.repr { // <-- Doesn't work because repr is private
            // moreover the following is too complicated: requires the knowledge of ErrorRepr
            ErrorRepr::Custom(kind, error) => { /* match and check erro, which is a Box */ }
            _ ....
        };
    }
```