### PR TITLE
chore: upgrade to stable toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, macos-latest]
-        # TODO: Bring `stable` back to the matrix once Rust 1.70.0+ compatibility is resolved in nearcore:
-        # https://github.com/near/nearcore/issues/9143
-        toolchain: [1.69.0]
+        toolchain: [stable]
 
     runs-on: ${{ matrix.platform }}
     steps:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ## Requirements
 
-- Rust v1.69.0 and up (NOTE: [contracts compiled w/ 1.70+ will fail currently](https://github.com/near/nearcore/issues/9143))
+- Rust v1.69.0 and up.
 - MacOS (x86 and M1) or Linux (x86) for sandbox tests.
 
 ### WASM compilation not supported

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -5,7 +5,7 @@ fn main() {
     let env_bin = std::env::var("NEAR_SANDBOX_BIN_PATH").is_ok();
     if !doc_build && !env_bin && cfg!(feature = "install") {
         // TODO Update commit to stable version once binaries are published correctly
-        // Commit: https://github.com/near/nearcore/commit/dce4c514f60a7f7981f00290268af4faf7eec55c
+        // Commit: https://github.com/near/nearcore/commit/eb2bbe1c3f51912c04462ce988aa496fab03d60e
         near_sandbox_utils::install_with_version("master/eb2bbe1c3f51912c04462ce988aa496fab03d60e")
             .expect("Could not install sandbox");
     }

--- a/workspaces/build.rs
+++ b/workspaces/build.rs
@@ -5,6 +5,8 @@ fn main() {
     let env_bin = std::env::var("NEAR_SANDBOX_BIN_PATH").is_ok();
     if !doc_build && !env_bin && cfg!(feature = "install") {
         // TODO Update commit to stable version once binaries are published correctly
-        near_sandbox_utils::install().expect("Could not install sandbox");
+        // Commit: https://github.com/near/nearcore/commit/dce4c514f60a7f7981f00290268af4faf7eec55c
+        near_sandbox_utils::install_with_version("master/eb2bbe1c3f51912c04462ce988aa496fab03d60e")
+            .expect("Could not install sandbox");
     }
 }


### PR DESCRIPTION
The issue involving wasm contract builds for Rust toolchain 1.70 and later: https://github.com/near/nearcore/issues/9143 has been resolved 
Should be ok to update the toolchain.

<s>Are we updating to toolchain `1.70` or ok to use `stable`?</s>