### PR TITLE
chore: cleanup unused `keystore_path`

### DIFF
--- a/workspaces/src/network/betanet.rs
+++ b/workspaces/src/network/betanet.rs
@@ -4,8 +4,6 @@ use crate::network::builder::{FromNetworkBuilder, NetworkBuilder};
 use crate::network::{Info, NetworkClient, NetworkInfo};
 use crate::rpc::client::Client;
 
-use std::path::PathBuf;
-
 /// URL to the betanet RPC node provided by near.org.
 pub const RPC_URL: &str = "https://rpc.betanet.near.org";
 
@@ -37,7 +35,6 @@ impl FromNetworkBuilder for Betanet {
             info: Info {
                 name: build.name.into(),
                 root_id: "near".parse().unwrap(),
-                keystore_path: PathBuf::from(".near-credentials/betanet/"),
                 rpc_url: Url::parse(&rpc_url).expect("url is hardcoded"),
             },
         })

--- a/workspaces/src/network/info.rs
+++ b/workspaces/src/network/info.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use crate::types::AccountId;
 
 pub struct Info {
@@ -7,8 +5,6 @@ pub struct Info {
     pub name: String,
     /// Root Account ID of the network. Mainnet has `near`, testnet has `testnet`.
     pub root_id: AccountId,
-    /// Path to the keystore directory
-    pub keystore_path: PathBuf,
 
     /// Rpc endpoint to point our client to
     pub rpc_url: url::Url,

--- a/workspaces/src/network/mainnet.rs
+++ b/workspaces/src/network/mainnet.rs
@@ -1,7 +1,6 @@
 use crate::network::{Info, NetworkClient, NetworkInfo};
 use crate::result::Result;
 use crate::rpc::client::Client;
-use std::path::PathBuf;
 
 use super::builder::{FromNetworkBuilder, NetworkBuilder};
 
@@ -38,7 +37,6 @@ impl FromNetworkBuilder for Mainnet {
             info: Info {
                 name: build.name.into(),
                 root_id: "near".parse().unwrap(),
-                keystore_path: PathBuf::from(".near-credentials/mainnet/"),
                 rpc_url: url::Url::parse(&rpc_url).expect("url is hardcodeed"),
             },
         })

--- a/workspaces/src/network/sandbox.rs
+++ b/workspaces/src/network/sandbox.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use async_trait::async_trait;
@@ -97,7 +96,6 @@ impl FromNetworkBuilder for Sandbox {
         let info = Info {
             name: build.name.into(),
             root_id: AccountId::from_str("test.near").unwrap(),
-            keystore_path: PathBuf::from(".near-credentials/sandbox/"),
             rpc_url: url::Url::parse(&server.rpc_addr()).expect("url is hardcoded"),
         };
 

--- a/workspaces/src/network/testnet.rs
+++ b/workspaces/src/network/testnet.rs
@@ -1,4 +1,3 @@
-use std::path::PathBuf;
 use std::str::FromStr;
 
 use async_trait::async_trait;
@@ -47,7 +46,6 @@ impl FromNetworkBuilder for Testnet {
             info: Info {
                 name: build.name.into(),
                 root_id: AccountId::from_str("testnet").unwrap(),
-                keystore_path: PathBuf::from(".near-credentials/testnet/"),
                 rpc_url: Url::parse(&rpc_url).expect("url is hardcoded"),
             },
         })


### PR DESCRIPTION
The `keystore_path` is unused, there's an issue [here](https://github.com/near/workspaces-rs/issues/196) indicating the need for a key loader. 

The keyloader is one of those features that might be rarely used but while reviewing you can nudge me to work on it, I had already started a wip implementation.