### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.12.0...near-workspaces-v0.13.0) - 2024-09-10
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.25 ([#375](https://github.com/near/near-workspaces-rs/pull/375))
+- replace `cargo-near` with `cargo-near-build` ([#373](https://github.com/near/near-workspaces-rs/pull/373))
+
 ## [0.12.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.11.1...near-workspaces-v0.12.0) - 2024-08-15
 
 ### Other

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2018"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
## 🤖 New release
* `near-workspaces`: 0.12.0 -> 0.13.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.12.0...near-workspaces-v0.13.0) - 2024-09-10

### Other

- [**breaking**] updates near-* dependencies to 0.25 ([#375](https://github.com/near/near-workspaces-rs/pull/375))
- replace `cargo-near` with `cargo-near-build` ([#373](https://github.com/near/near-workspaces-rs/pull/373))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).