### PR TITLE
feat: update max gas limit to 1 PGas

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Afterwards, let's mint an NFT via `nft_mint`. This showcases some extra argument
         }))
         .deposit(deposit)
         // nft_mint might consume more than default gas, so supply our own gas value:
-        .gas(NearGas::from_tgas(300))
+        .gas(NearGas::from_tgas(1_000))
         .transact()
         .await?;
 

--- a/workspaces/src/operations.rs
+++ b/workspaces/src/operations.rs
@@ -29,7 +29,7 @@ use std::future::IntoFuture;
 use std::pin::Pin;
 use std::task::Poll;
 
-const MAX_GAS: NearGas = NearGas::from_tgas(300);
+const MAX_GAS: NearGas = NearGas::from_tgas(1_000);
 
 /// A set of arguments we can provide to a transaction, containing
 /// the function name, arguments, the amount of gas to use and deposit.


### PR DESCRIPTION
## Summary

- Update `MAX_GAS` constant from 300 TGas to 1 PGas (1000 TGas) to match nearcore 2.11 protocol change
- Update documentation and examples referencing the old 300 TGas limit

Ref: near/devex#4