### PR TITLE
chore: update near-* crates to 0.35

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.34"
-near-primitives = "0.34"
+near-jsonrpc-primitives = "0.35"
+near-primitives = "0.35"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/noop-contract/Cargo.toml
+++ b/examples/noop-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.25.0"
+near-sdk = "5.26.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/noop-contract/Cargo.toml
+++ b/examples/noop-contract/Cargo.toml
@@ -2,13 +2,13 @@
 name = "simple-contract"
 version = "0.1.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.7.0"
+near-sdk = "5.25.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/simple-contract/Cargo.toml
+++ b/examples/simple-contract/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.25.0"
+near-sdk = "5.26.0"
 
 [profile.release]
 codegen-units = 1

--- a/examples/simple-contract/Cargo.toml
+++ b/examples/simple-contract/Cargo.toml
@@ -2,13 +2,13 @@
 name = "simple-contract"
 version = "0.1.0"
 publish = false
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.7.0"
+near-sdk = "5.25.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -33,17 +33,17 @@ url = { version = "2.2.2", features = ["serde"] }
 near-abi-client = "0.1.1"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
-near-sdk = { version = "5.7", optional = true }
+near-sdk = { version = "5.25", optional = true }
 near-account-id = "2.0.0"
-near-crypto = "0.34"
-near-primitives = "0.34"
-near-jsonrpc-primitives = "0.34"
-near-jsonrpc-client = { version = "0.20", features = ["sandbox"] }
-near-sandbox = "0.3.1"
-near-chain-configs = { version = "0.34", optional = true }
+near-crypto = "0.35"
+near-primitives = "0.35"
+near-jsonrpc-primitives = "0.35"
+near-jsonrpc-client = { version = "0.21", features = ["sandbox"] }
+near-sandbox = "0.3.9"
+near-chain-configs = { version = "0.35", optional = true }
 
 [build-dependencies]
-near-sandbox = "0.3.1"
+near-sandbox = "0.3.9"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -51,7 +51,7 @@ libc = "0.2"
 [dev-dependencies]
 anyhow = "1.0"
 futures = "0.3"
-near-sdk = { version = "5.20", features = ["unit-testing"] }
+near-sdk = { version = "5.25", features = ["unit-testing"] }
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -33,7 +33,7 @@ url = { version = "2.2.2", features = ["serde"] }
 near-abi-client = "0.1.1"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
-near-sdk = { version = "5.25", optional = true }
+near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
 near-crypto = "0.35"
 near-primitives = "0.35"
@@ -51,7 +51,7 @@ libc = "0.2"
 [dev-dependencies]
 anyhow = "1.0"
 futures = "0.3"
-near-sdk = { version = "5.25", features = ["unit-testing"] }
+near-sdk = { version = "5.26", features = ["unit-testing"] }
 test-log = { version = "0.2.8", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.5", features = ["env-filter"] }
 

--- a/workspaces/src/rpc/client.rs
+++ b/workspaces/src/rpc/client.rs
@@ -47,7 +47,6 @@ use crate::{Network, Worker};
 
 pub(crate) const DEFAULT_CALL_FN_GAS: NearGas = NearGas::from_tgas(10);
 pub(crate) const DEFAULT_CALL_DEPOSIT: NearToken = NearToken::from_near(0);
-pub(crate) const DEFAULT_PRIORITY_FEE: u64 = 0;
 
 /// A client that wraps around [`JsonRpcClient`], and provides more capabilities such
 /// as retry w/ exponential backoff and utility functions for sending transactions.
@@ -569,7 +568,6 @@ pub(crate) async fn send_batch_tx_and_retry(
                 &inner,
                 actions.clone(),
                 block_hash,
-                DEFAULT_PRIORITY_FEE,
             ),
         )
         .await
@@ -600,7 +598,6 @@ pub(crate) async fn send_batch_tx_async_and_retry(
                     &inner,
                     actions.clone(),
                     block_hash,
-                    DEFAULT_PRIORITY_FEE,
                 ),
             })
             .await

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -524,6 +524,10 @@ impl From<near_primitives::views::AccessKeyView> for AccessKey {
                 near_primitives::views::AccessKeyPermissionView::FullAccess => {
                     AccessKeyPermission::FullAccess
                 }
+                near_primitives::views::AccessKeyPermissionView::GasKeyFunctionCall { .. }
+                | near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess { .. } => {
+                    unimplemented!()
+                }
             },
         }
     }

--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.25.0"
+near-sdk = "5.26.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -2,13 +2,13 @@
 name = "test-contract-status-message"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
-near-sdk = "5.19.0"
+near-sdk = "5.25.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/type-serialize/Cargo.toml
+++ b/workspaces/tests/test-contracts/type-serialize/Cargo.toml
@@ -2,14 +2,14 @@
 name = "test-contract-type-serialization"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
-edition = "2018"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib"]
 
 [dependencies]
 bs58 = "0.5"
-near-sdk = "5.19.0"
+near-sdk = "5.25.0"
 
 [profile.release]
 codegen-units = 1

--- a/workspaces/tests/test-contracts/type-serialize/Cargo.toml
+++ b/workspaces/tests/test-contracts/type-serialize/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 bs58 = "0.5"
-near-sdk = "5.25.0"
+near-sdk = "5.26.0"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
Should be merged after [near/near-sdk-rs#1527](https://github.com/near/near-sdk-rs/pull/1527) and near-sdk-sdk v 5.25.1