### PR TITLE
fix: use edition 2024 in test contracts for MSRV-aware resolution

### DIFF
--- a/workspaces/tests/test-contracts/status-message/Cargo.toml
+++ b/workspaces/tests/test-contracts/status-message/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-contract-status-message"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
+rust-version = "1.86"
 
 [lib]
 crate-type = ["cdylib"]

--- a/workspaces/tests/test-contracts/type-serialize/Cargo.toml
+++ b/workspaces/tests/test-contracts/type-serialize/Cargo.toml
@@ -3,6 +3,7 @@ name = "test-contract-type-serialization"
 version = "0.0.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2024"
+rust-version = "1.86"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
## Summary
- The standalone test contracts (`status-message`, `type-serialize`) were still on edition 2018 with no `rust-version` set
- Cargo's default resolver would pull in newer transitive deps (`darling 0.23.0`, `serde_with 3.18.0`) requiring rustc 1.88, breaking the 1.86 toolchain build
- Bumping to edition 2024 enables resolver v3 which respects `rust-version = "1.86"`, keeping deps compatible

## Test plan
- [ ] CI passes — `test_dev_deploy_project` should no longer fail