### PR TITLE
chore: bump nearcore crates to 0.36 (2.12 / protocol 84)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Install cargo-near CLI (dependency for examples' build)
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.15.0/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.20.2/cargo-near-installer.sh | sh
       - uses: Swatinem/rust-cache@v2
       - name: Add wasm32 target
         run: rustup target add wasm32-unknown-unknown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,10 +67,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           default: true
 
-      - name: "Install pinned 1.93.0 Rust toolchain for compiling contracts for tests with live node"
+      - name: "Install pinned 1.86.0 Rust toolchain for compiling contracts for tests with live node"
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.93.0
+          toolchain: 1.86.0
           default: false
           profile: minimal
           target: wasm32-unknown-unknown

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,14 +40,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: "Install pinned 1.86.0 Rust toolchain for to workaround https://github.com/rust-lang/rust/issues/148431"
+      - name: "Install pinned 1.93.0 Rust toolchain for to workaround https://github.com/rust-lang/rust/issues/148431"
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.86.0
+          toolchain: 1.93.0
           default: true
           profile: minimal
       - name: run cargo doc
-        run: RUSTDOCFLAGS="-D warnings" cargo +1.86.0 doc
+        run: RUSTDOCFLAGS="-D warnings" cargo +1.93.0 doc
 
   test:
     needs: cargo-fmt
@@ -67,10 +67,10 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           default: true
 
-      - name: "Install pinned 1.86.0 Rust toolchain for compiling contracts for tests with live node"
+      - name: "Install pinned 1.93.0 Rust toolchain for compiling contracts for tests with live node"
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.86.0
+          toolchain: 1.93.0
           default: false
           profile: minimal
           target: wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,7 @@ members = ["workspaces", "examples"]
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.86"
+rust-version = "1.93"
+
+[patch.crates-io]
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs.git", branch = "bump/nearcore-2.12" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ members = ["workspaces", "examples"]
 [workspace.package]
 edition = "2024"
 rust-version = "1.93"
-
-[patch.crates-io]
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs.git", branch = "bump/nearcore-2.12" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.35"
-near-primitives = "0.35"
+near-jsonrpc-primitives = "0.36.0-rc.1"
+near-primitives = "0.36.0-rc.1"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.36.0-rc.2"
-near-primitives = "0.36.0-rc.2"
+near-jsonrpc-primitives = "0.36.0"
+near-primitives = "0.36.0"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.36.0-rc.1"
-near-primitives = "0.36.0-rc.1"
+near-jsonrpc-primitives = "0.36.0-rc.2"
+near-primitives = "0.36.0-rc.2"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -35,12 +35,12 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-near-crypto = "0.36.0-rc.1"
-near-primitives = "0.36.0-rc.1"
-near-jsonrpc-primitives = "0.36.0-rc.1"
+near-crypto = "0.36.0-rc.2"
+near-primitives = "0.36.0-rc.2"
+near-jsonrpc-primitives = "0.36.0-rc.2"
 near-jsonrpc-client = { version = "0.21", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { version = "0.36.0-rc.1", optional = true }
+near-chain-configs = { version = "0.36.0-rc.2", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -14,7 +14,7 @@ Library for automating workflows and testing NEAR smart contracts.
 async-trait = "0.1"
 base64 = "0.22"
 bs58 = "0.5"
-cargo-near-build = { version = "0.11.0", optional = true }
+cargo-near-build = { version = "0.11.2", optional = true }
 chrono = "0.4.19"
 fs2 = "0.4"
 rand = "0.8.4"
@@ -35,12 +35,12 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-near-crypto = "0.35"
-near-primitives = "0.35"
-near-jsonrpc-primitives = "0.35"
+near-crypto = "0.36.0-rc.1"
+near-primitives = "0.36.0-rc.1"
+near-jsonrpc-primitives = "0.36.0-rc.1"
 near-jsonrpc-client = { version = "0.21", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { version = "0.35", optional = true }
+near-chain-configs = { version = "0.36.0-rc.1", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -35,12 +35,12 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-near-crypto = "0.36.0-rc.2"
-near-primitives = "0.36.0-rc.2"
-near-jsonrpc-primitives = "0.36.0-rc.2"
+near-crypto = "0.36.0"
+near-primitives = "0.36.0"
+near-jsonrpc-primitives = "0.36.0"
 near-jsonrpc-client = { version = "0.21", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { version = "0.36.0-rc.2", optional = true }
+near-chain-configs = { version = "0.36.0", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/src/cargo/mod.rs
+++ b/workspaces/src/cargo/mod.rs
@@ -25,6 +25,10 @@ pub async fn compile_project(project_path: &str) -> crate::Result<Vec<u8>> {
                 ))
             })?,
         ),
+        // Allow compiling contracts on toolchains newer than what the contract's
+        // Cargo.toml declares — unblocks SDK 2.12 example tests, where the
+        // contract's rust-version may lag behind the host toolchain.
+        skip_rust_version_check: true,
         ..Default::default()
     };
 

--- a/workspaces/src/network/server.rs
+++ b/workspaces/src/network/server.rs
@@ -102,10 +102,10 @@ impl Drop for SandboxServer {
 /// will be forward into RUST_LOG environment variable as to not conflict
 /// with similar named log targets.
 fn suppress_sandbox_logs_if_required() {
-    if let Ok(val) = std::env::var("NEAR_ENABLE_SANDBOX_LOG") {
-        if val != "0" {
-            return;
-        }
+    if let Ok(val) = std::env::var("NEAR_ENABLE_SANDBOX_LOG")
+        && val != "0"
+    {
+        return;
     }
 
     // NOTE: (vsavchyn-dev), 2024 edition requires it be inside an unsafe block.

--- a/workspaces/tests/deploy_project.rs
+++ b/workspaces/tests/deploy_project.rs
@@ -20,7 +20,8 @@ async fn test_dev_deploy_project() -> anyhow::Result<()> {
                 )
                 .join("Cargo.toml"),
             )
-            .override_toolchain("1.86.0")
+            .override_toolchain("1.93.0")
+            .skip_rust_version_check(true)
             .build();
         let compile_artifact = near_build::build_with_cli(build_opts)
             .map_err(|e| Error::custom(ErrorKind::Other, e))?;

--- a/workspaces/tests/deploy_project.rs
+++ b/workspaces/tests/deploy_project.rs
@@ -20,7 +20,7 @@ async fn test_dev_deploy_project() -> anyhow::Result<()> {
                 )
                 .join("Cargo.toml"),
             )
-            .override_toolchain("1.93.0")
+            .override_toolchain("1.86.0")
             .skip_rust_version_check(true)
             .build();
         let compile_artifact = near_build::build_with_cli(build_opts)


### PR DESCRIPTION
Bumps the nearcore deps (near-crypto, near-primitives, near-jsonrpc-primitives, near-chain-configs) from 0.35 to 0.36 for NEAR 2.12, now live on mainnet, along with cargo-near-build 0.11.2 (forwarding the new `skip_rust_version_check` flag) and the workspace MSRV to 1.93.

Builds against the published near-jsonrpc-client 0.21.1; the pre-publish `[patch.crates-io]` git pin has been removed.