### PR TITLE
feat: support nearcore 2.13 / post-quantum ML-DSA-65

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.37.0-rc.1"
-near-primitives = "0.37.0-rc.1"
+near-jsonrpc-primitives = "0.37.0-rc.2"
+near-primitives = "0.37.0-rc.2"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.37.0-rc.2"
-near-primitives = "0.37.0-rc.2"
+near-jsonrpc-primitives = "=0.37.0-rc.2"
+near-primitives = "=0.37.0-rc.2"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-primitives = "0.37.0-rc.1"
+near-primitives = "0.37.0-rc.1"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "0.36.0"
-near-primitives = "0.36.0"
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -40,7 +40,7 @@ near-account-id = "2.0.0"
 near-crypto = "0.37.0-rc.2"
 near-primitives = "0.37.0-rc.2"
 near-jsonrpc-primitives = "0.37.0-rc.2"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e", features = ["sandbox"] }
+near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["sandbox"] }
 near-sandbox = "0.3.9"
 near-chain-configs = { version = "0.37.0-rc.2", optional = true }
 

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -35,17 +35,14 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-# DRAFT: nearcore 2.13 (protocol v85) is not on crates.io yet. Pin the
-# nearcore-versioned crates to the same 2.13-release rev that the sibling
-# near-jsonrpc-client 2.13 draft pins, so all nearcore types unify (cargo
-# only unifies identical git sources; a bare branch pin would clash with
-# jsonrpc-client's rev pin and duplicate near-primitives).
-near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95", features = ["sandbox"] }
+# DRAFT: published 2.13 RC 0.37.0-rc.1; bump to 0.37.0 (drop pre-release)
+# once 2.13 ships stable.
+near-crypto = "0.37.0-rc.1"
+near-primitives = "0.37.0-rc.1"
+near-jsonrpc-primitives = "0.37.0-rc.1"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10", optional = true }
+near-chain-configs = { version = "0.37.0-rc.1", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -35,12 +35,17 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-near-crypto = "0.36.0"
-near-primitives = "0.36.0"
-near-jsonrpc-primitives = "0.36.0"
-near-jsonrpc-client = { version = "0.21.1", features = ["sandbox"] }
+# DRAFT: nearcore 2.13 (protocol v85) is not on crates.io yet. Pin the
+# nearcore-versioned crates to the same 2.13-release rev that the sibling
+# near-jsonrpc-client 2.13 draft pins, so all nearcore types unify (cargo
+# only unifies identical git sources; a bare branch pin would clash with
+# jsonrpc-client's rev pin and duplicate near-primitives).
+near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { version = "0.36.0", optional = true }
+near-chain-configs = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -37,12 +37,12 @@ near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
 # DRAFT: published 2.13 RC 0.37.0-rc.2; bump to 0.37.0 (drop pre-release)
 # once 2.13 ships stable.
-near-crypto = "0.37.0-rc.2"
-near-primitives = "0.37.0-rc.2"
-near-jsonrpc-primitives = "0.37.0-rc.2"
+near-crypto = "=0.37.0-rc.2"
+near-primitives = "=0.37.0-rc.2"
+near-jsonrpc-primitives = "=0.37.0-rc.2"
 near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { version = "0.37.0-rc.2", optional = true }
+near-chain-configs = { version = "=0.37.0-rc.2", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -35,14 +35,14 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-# DRAFT: published 2.13 RC 0.37.0-rc.1; bump to 0.37.0 (drop pre-release)
+# DRAFT: published 2.13 RC 0.37.0-rc.2; bump to 0.37.0 (drop pre-release)
 # once 2.13 ships stable.
-near-crypto = "0.37.0-rc.1"
-near-primitives = "0.37.0-rc.1"
-near-jsonrpc-primitives = "0.37.0-rc.1"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d", features = ["sandbox"] }
+near-crypto = "0.37.0-rc.2"
+near-primitives = "0.37.0-rc.2"
+near-jsonrpc-primitives = "0.37.0-rc.2"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e", features = ["sandbox"] }
 near-sandbox = "0.3.9"
-near-chain-configs = { version = "0.37.0-rc.1", optional = true }
+near-chain-configs = { version = "0.37.0-rc.2", optional = true }
 
 [build-dependencies]
 near-sandbox = "0.3.9"

--- a/workspaces/src/rpc/patch.rs
+++ b/workspaces/src/rpc/patch.rs
@@ -199,7 +199,8 @@ impl PatchTransaction {
     pub fn access_key(mut self, pk: PublicKey, ak: AccessKey) -> Self {
         self.records.push(StateRecord::AccessKey {
             account_id: self.account_id.clone(),
-            public_key: pk.into(),
+            // since nearcore 2.13 this field is a `PublicKeyHandle`
+            public_key: pk.0.into(),
             access_key: ak.into(),
         });
         self
@@ -222,7 +223,8 @@ impl PatchTransaction {
                 .into_iter()
                 .map(|(pk, ak)| StateRecord::AccessKey {
                     account_id: account_id.clone(),
-                    public_key: pk.into(),
+                    // since nearcore 2.13 this field is a `PublicKeyHandle`
+                    public_key: pk.0.into(),
                     access_key: ak.into(),
                 }),
         );

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -371,9 +371,11 @@ impl ProcessQuery for ViewAccessKeyList {
 
     fn from_response(resp: <Self::Method as RpcMethod>::Response) -> Result<Self::Output> {
         match resp.kind {
-            QueryResponseKind::AccessKeyList(keylist) => {
-                Ok(keylist.keys.into_iter().map(Into::into).collect())
-            }
+            QueryResponseKind::AccessKeyList(keylist) => keylist
+                .keys
+                .into_iter()
+                .map(AccessKeyInfo::try_from)
+                .collect(),
             _ => Err(RpcErrorCode::QueryReturnedInvalidData.message("while querying access keys")),
         }
     }

--- a/workspaces/src/rpc/query.rs
+++ b/workspaces/src/rpc/query.rs
@@ -301,6 +301,8 @@ impl ProcessQuery for ViewState {
             request: QueryRequest::ViewState {
                 account_id: self.account_id,
                 prefix: StoreKey::from(self.prefix.unwrap_or_default()),
+                after_key: None,
+                limit: None,
                 include_proof: false,
             },
         })

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -450,22 +450,27 @@ pub struct AccessKeyInfo {
     pub access_key: AccessKey,
 }
 
-impl From<near_primitives::views::AccessKeyInfoView> for AccessKeyInfo {
-    fn from(view: near_primitives::views::AccessKeyInfoView) -> Self {
+impl TryFrom<near_primitives::views::AccessKeyInfoView> for AccessKeyInfo {
+    type Error = crate::error::Error;
+
+    fn try_from(
+        view: near_primitives::views::AccessKeyInfoView,
+    ) -> std::result::Result<Self, Self::Error> {
         // Since nearcore 2.13 the view holds a `PublicKeyHandle`; `full_pubkey`
         // recovers the underlying key for ED25519/SECP256K1 and yields `None`
         // for post-quantum ML-DSA-65 keys, whose full 1952-byte pubkey is not
         // recoverable from the 32-byte on-trie hash the handle carries. Such
         // access keys can be created and signed with, but cannot be listed via
-        // this view.
-        let public_key = view
-            .public_key
-            .full_pubkey()
-            .expect("ML-DSA-65 access keys cannot be recovered from their on-trie hash");
-        Self {
+        // this view, so we return an error rather than panicking.
+        let public_key = view.public_key.full_pubkey().ok_or_else(|| {
+            ErrorKind::DataConversion.custom(
+                "ML-DSA-65 access key cannot be listed: its full public key is not recoverable from the on-trie hash",
+            )
+        })?;
+        Ok(Self {
             public_key: PublicKey(public_key),
             access_key: view.access_key.into(),
-        }
+        })
     }
 }
 

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -71,6 +71,9 @@ impl KeyType {
         match key_type {
             near_crypto::KeyType::ED25519 => Self::ED25519,
             near_crypto::KeyType::SECP256K1 => Self::SECP256K1,
+            // near-workspaces does not model nearcore 2.13's post-quantum
+            // ML-DSA-65 keys; they cannot be produced by this crate's APIs.
+            near_crypto::KeyType::MLDSA65 => panic!("ML-DSA-65 keys are not supported"),
         }
     }
 
@@ -441,8 +444,15 @@ pub struct AccessKeyInfo {
 
 impl From<near_primitives::views::AccessKeyInfoView> for AccessKeyInfo {
     fn from(view: near_primitives::views::AccessKeyInfoView) -> Self {
+        // Since nearcore 2.13 the view holds a `PublicKeyHandle`; `full_pubkey`
+        // recovers the underlying key for ED25519/SECP256K1 and yields `None`
+        // only for post-quantum ML-DSA-65 keys, which this crate does not model.
+        let public_key = view
+            .public_key
+            .full_pubkey()
+            .expect("ML-DSA-65 keys are not supported");
         Self {
-            public_key: PublicKey(view.public_key),
+            public_key: PublicKey(public_key),
             access_key: view.access_key.into(),
         }
     }

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -84,10 +84,7 @@ impl KeyType {
         match self {
             Self::ED25519 => 32,
             Self::SECP256K1 => 64,
-            // `near_crypto::ML_DSA_65_PUBLIC_KEY_LENGTH`; the full ML-DSA-65
-            // public key. (The constant isn't re-exported, so it's hardcoded
-            // here just like the ED25519/SECP256K1 lengths above.)
-            Self::MLDSA65 => 1952,
+            Self::MLDSA65 => near_crypto::ML_DSA_65_PUBLIC_KEY_LENGTH,
         }
     }
 }

--- a/workspaces/src/types/mod.rs
+++ b/workspaces/src/types/mod.rs
@@ -57,6 +57,9 @@ fn from_base58(s: &str) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sy
 pub enum KeyType {
     ED25519 = 0,
     SECP256K1 = 1,
+    /// FIPS 204 ML-DSA-65, the post-quantum signature scheme stabilized in
+    /// nearcore 2.13 (protocol v85).
+    MLDSA65 = 2,
 }
 
 impl KeyType {
@@ -64,6 +67,7 @@ impl KeyType {
         match self {
             Self::ED25519 => near_crypto::KeyType::ED25519,
             Self::SECP256K1 => near_crypto::KeyType::SECP256K1,
+            Self::MLDSA65 => near_crypto::KeyType::MLDSA65,
         }
     }
 
@@ -71,9 +75,7 @@ impl KeyType {
         match key_type {
             near_crypto::KeyType::ED25519 => Self::ED25519,
             near_crypto::KeyType::SECP256K1 => Self::SECP256K1,
-            // near-workspaces does not model nearcore 2.13's post-quantum
-            // ML-DSA-65 keys; they cannot be produced by this crate's APIs.
-            near_crypto::KeyType::MLDSA65 => panic!("ML-DSA-65 keys are not supported"),
+            near_crypto::KeyType::MLDSA65 => Self::MLDSA65,
         }
     }
 
@@ -82,6 +84,10 @@ impl KeyType {
         match self {
             Self::ED25519 => 32,
             Self::SECP256K1 => 64,
+            // `near_crypto::ML_DSA_65_PUBLIC_KEY_LENGTH`; the full ML-DSA-65
+            // public key. (The constant isn't re-exported, so it's hardcoded
+            // here just like the ED25519/SECP256K1 lengths above.)
+            Self::MLDSA65 => 1952,
         }
     }
 }
@@ -110,6 +116,7 @@ impl TryFrom<u8> for KeyType {
         match value {
             0 => Ok(Self::ED25519),
             1 => Ok(Self::SECP256K1),
+            2 => Ok(Self::MLDSA65),
             unknown_key_type => Err(ErrorKind::DataConversion
                 .custom(format!("Unknown key type provided: {unknown_key_type}"))),
         }
@@ -162,8 +169,9 @@ impl PublicKey {
     }
 
     /// Get the number of bytes this key uses. This will differ depending on the [`KeyType`]. i.e. for
-    /// ED25519 keys, this will return 32 + 1, while for SECP256K1 keys, this will return 64 + 1. The +1
-    /// is used to store the key type, and will appear at the start of the serialized key.
+    /// ED25519 keys, this will return 32 + 1, while for SECP256K1 keys, this will return 64 + 1, and for
+    /// ML-DSA-65 keys, this will return 1952 + 1. The +1 is used to store the key type, and will appear
+    /// at the start of the serialized key.
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -446,11 +454,14 @@ impl From<near_primitives::views::AccessKeyInfoView> for AccessKeyInfo {
     fn from(view: near_primitives::views::AccessKeyInfoView) -> Self {
         // Since nearcore 2.13 the view holds a `PublicKeyHandle`; `full_pubkey`
         // recovers the underlying key for ED25519/SECP256K1 and yields `None`
-        // only for post-quantum ML-DSA-65 keys, which this crate does not model.
+        // for post-quantum ML-DSA-65 keys, whose full 1952-byte pubkey is not
+        // recoverable from the 32-byte on-trie hash the handle carries. Such
+        // access keys can be created and signed with, but cannot be listed via
+        // this view.
         let public_key = view
             .public_key
             .full_pubkey()
-            .expect("ML-DSA-65 keys are not supported");
+            .expect("ML-DSA-65 access keys cannot be recovered from their on-trie hash");
         Self {
             public_key: PublicKey(public_key),
             access_key: view.access_key.into(),

--- a/workspaces/tests/account.rs
+++ b/workspaces/tests/account.rs
@@ -1,5 +1,6 @@
 #![recursion_limit = "256"]
 use near_token::NearToken;
+use near_workspaces::types::{KeyType, SecretKey};
 use serde_json::{Map, Value};
 use test_log::test;
 
@@ -63,6 +64,43 @@ async fn test_transfer_near() -> anyhow::Result<()> {
 
     // We can only assert that the balance is less than the initial balance - sent amount because of the gas fees.
     assert!(alice.view_account().await?.balance <= INITIAL_BALANCE.saturating_sub(SENT_AMOUNT));
+
+    Ok(())
+}
+
+#[test(tokio::test)]
+async fn test_mldsa65_access_key_on_chain() -> anyhow::Result<()> {
+    // ML-DSA-65 (FIPS 204) access keys were stabilized in nearcore 2.13 /
+    // protocol v85. The default near-sandbox is v84 and lacks the scheme, so
+    // pin a v85 sandbox (published for linux-x86_64 + darwin) to exercise it.
+    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let root = worker.root_account()?;
+
+    // Fund a fresh subaccount whose full-access key is post-quantum.
+    let sk = SecretKey::from_random(KeyType::MLDSA65);
+    let sub = root
+        .create_subaccount("pqkey")
+        .keys(sk.clone())
+        .initial_balance(NearToken::from_near(10))
+        .transact()
+        .await?
+        .into_result()?;
+
+    // The on-chain account is keyed with ML-DSA-65.
+    assert!(matches!(sub.secret_key().key_type(), KeyType::MLDSA65));
+
+    // Signing a real transfer forces the sandbox to verify an ML-DSA-65
+    // signature; this is the actual proof the scheme works end-to-end.
+    sub.transfer_near(root.id(), NearToken::from_near(1))
+        .await?
+        .into_result()?;
+
+    // After sending 1 NEAR (plus gas) the subaccount must hold under 9 NEAR.
+    let remaining = sub.view_account().await?.balance;
+    assert!(
+        remaining < NearToken::from_near(9),
+        "expected balance below 9 NEAR after the transfer, got {remaining}"
+    );
 
     Ok(())
 }

--- a/workspaces/tests/account.rs
+++ b/workspaces/tests/account.rs
@@ -102,6 +102,14 @@ async fn test_mldsa65_access_key_on_chain() -> anyhow::Result<()> {
         "expected balance below 9 NEAR after the transfer, got {remaining}"
     );
 
+    // The account's only access key is ML-DSA-65, whose full public key cannot
+    // be recovered from the on-trie hash. Listing keys must return an error
+    // gracefully rather than panicking.
+    assert!(
+        sub.view_access_keys().await.is_err(),
+        "listing a hash-only ML-DSA-65 access key should error, not panic"
+    );
+
     Ok(())
 }
 

--- a/workspaces/tests/types.rs
+++ b/workspaces/tests/types.rs
@@ -41,6 +41,40 @@ fn test_keypair_secp256k1() -> anyhow::Result<()> {
 }
 
 #[test]
+fn test_keypair_mldsa65() -> anyhow::Result<()> {
+    // ML-DSA-65 keygen and string round-tripping, without a sandbox.
+    for sk in [
+        SecretKey::from_random(KeyType::MLDSA65),
+        SecretKey::from_seed(KeyType::MLDSA65, "test"),
+    ] {
+        assert!(matches!(sk.key_type(), KeyType::MLDSA65));
+
+        let pk = sk.public_key();
+        assert!(matches!(pk.key_type(), KeyType::MLDSA65));
+        // Full ML-DSA-65 public key is 1952 bytes of key data (1953 with the
+        // leading key-type byte).
+        assert_eq!(pk.key_data().len(), 1952);
+        assert_eq!(pk.len(), 1953);
+        assert_eq!(KeyType::MLDSA65.data_len(), 1952);
+
+        // Both keys round-trip through their `ml-dsa-65:`-prefixed string form.
+        let pk_str = pk.to_string();
+        assert!(pk_str.starts_with("ml-dsa-65:"), "got {pk_str}");
+        assert_eq!(PublicKey::from_str(&pk_str)?, pk);
+
+        let sk_str = sk.to_string();
+        assert!(sk_str.starts_with("ml-dsa-65:"), "got {sk_str}");
+        assert_eq!(SecretKey::from_str(&sk_str)?, sk);
+    }
+
+    // The numeric and string discriminants both resolve to ML-DSA-65.
+    assert!(matches!(KeyType::try_from(2u8)?, KeyType::MLDSA65));
+    assert!(matches!(KeyType::from_str("ml-dsa-65")?, KeyType::MLDSA65));
+
+    Ok(())
+}
+
+#[test]
 fn test_pubkey_serialization() -> anyhow::Result<()> {
     for key_type in [KeyType::ED25519, KeyType::SECP256K1] {
         let sk = SecretKey::from_seed(key_type, "test");


### PR DESCRIPTION
## Summary

Adds nearcore 2.13 (protocol v85) / post-quantum ML-DSA-65 support. The nearcore-versioned `near-*` crates are pinned to the published 2.13 release candidates on crates.io (no git dependencies):

- `near-crypto`, `near-primitives`, `near-jsonrpc-primitives`, `near-chain-configs` → `=0.37.0-rc.2`
- `near-jsonrpc-client` → `=0.22.0-rc.1` (keeps the `sandbox` feature)

Exact (`=`) pins so the RC line doesn't float. `examples/Cargo.toml` follows suit for its `near-primitives` / `near-jsonrpc-primitives` dev-deps. Once 2.13 ships stable these move to the released `0.37.0` / `0.22.0`.

## API changes adapted to (2.12 → 2.13)

- **`QueryRequest::ViewState`** gained `after_key` / `limit` (both `#[serde(default)]`); `workspaces/src/rpc/query.rs` passes `None`.
- **Access-key public keys are now `PublicKeyHandle`** (post-quantum-capable) instead of `near_crypto::PublicKey`. `workspaces/src/rpc/patch.rs` converts via the inner key; `workspaces/src/types/mod.rs`'s `From<AccessKeyInfoView>` recovers the key via `PublicKeyHandle::full_pubkey()`, returning an error (rather than panicking) when a hash-only ML-DSA-65 key can't be recovered from the on-trie hash.
- **`near_crypto::KeyType` gained `MLDSA65`.** `workspaces` now models it end-to-end: `KeyType::MLDSA65 = 2`, `data_len` via `ML_DSA_65_PUBLIC_KEY_LENGTH`, plus the `TryFrom<u8>` / `FromStr` / `PublicKey` paths.

## Checks

- `cargo check`: pass
- `cargo build --features unstable`: pass
- `cargo clippy --all-targets -- -D clippy::all`: pass (only a pre-existing `wasmparser` future-incompat note from a transitive dep)
- `cargo fmt --check`: pass
- `cargo doc` (`RUSTDOCFLAGS=-D warnings`): pass
- `cargo test --features unstable --no-run`: all test targets compile

Note: `--all-features` is not used — it activates `interop_sdk`, pulling `near-sdk` (on the 2.12 `near-primitives` line) and duplicating `near-primitives`.
