### PR TITLE
fix: require near-jsonrpc-client 0.21.1 to keep near-primitives on 0.36

### DIFF
--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -38,7 +38,7 @@ near-account-id = "2.0.0"
 near-crypto = "0.36.0"
 near-primitives = "0.36.0"
 near-jsonrpc-primitives = "0.36.0"
-near-jsonrpc-client = { version = "0.21", features = ["sandbox"] }
+near-jsonrpc-client = { version = "0.21.1", features = ["sandbox"] }
 near-sandbox = "0.3.9"
 near-chain-configs = { version = "0.36.0", optional = true }
 


### PR DESCRIPTION
**Problem:** `near-workspaces` requires `near-primitives 0.36` directly, but the loose `near-jsonrpc-client = "0.21"` also admits `0.21.0`, which requires `near-primitives ^0.35`. In any downstream workspace whose MSRV floor is below 1.93, the resolver selects `0.21.0` and the graph ends up with **two incompatible `near-primitives`** (0.35 + 0.36) — which fails to compile.

**Fix:** Pin the floor to `0.21.1`, the release that tracks `near-primitives 0.36`, so the nearcore crate set stays coordinated on a single minor.

```diff
- near-jsonrpc-client = { version = "0.21",   features = ["sandbox"] }
+ near-jsonrpc-client = { version = "0.21.1", features = ["sandbox"] }
```
