### PR TITLE
chore: release v0.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.4](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.3...near-workspaces-v0.22.4) - 2026-06-26
+
+### Fixed
+
+- require near-jsonrpc-client 0.21.1 to keep near-primitives on 0.36 ([#450](https://github.com/near/near-workspaces-rs/pull/450))
+
 ## [0.22.3](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.2...near-workspaces-v0.22.3) - 2026-06-22
 
 ### Added

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.22.3"
+version = "0.22.4"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-workspaces`: 0.22.3 -> 0.22.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.4](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.3...near-workspaces-v0.22.4) - 2026-06-26

### Fixed

- require near-jsonrpc-client 0.21.1 to keep near-primitives on 0.36 ([#450](https://github.com/near/near-workspaces-rs/pull/450))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).