### PR TITLE
chore: release v0.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0-rc.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.4...near-workspaces-v0.23.0-rc.1) - 2026-07-02
+
+### Added
+
+- support nearcore 2.13 / post-quantum ML-DSA-65 ([#449](https://github.com/near/near-workspaces-rs/pull/449))
+
 ## [0.22.4](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.3...near-workspaces-v0.22.4) - 2026-06-26
 
 ### Fixed

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.22.4"
+version = "0.23.0-rc.1"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `near-workspaces`: 0.22.4 -> 0.22.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.5](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.4...near-workspaces-v0.22.5) - 2026-07-02

### Added

- support nearcore 2.13 / post-quantum ML-DSA-65 ([#449](https://github.com/near/near-workspaces-rs/pull/449))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).