### PR TITLE
chore: pin to nearcore 2.13.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.23.0-rc.1](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.4...near-workspaces-v0.23.0-rc.1) - 2026-07-02
+## [0.23.0](https://github.com/near/near-workspaces-rs/compare/near-workspaces-v0.22.4...near-workspaces-v0.23.0) - 2026-07-09
 
 ### Added
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,8 +10,8 @@ anyhow = "1.0"
 maplit = "1.0"
 near-units = "0.2.0"
 near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
-near-jsonrpc-primitives = "=0.37.0-rc.2"
-near-primitives = "=0.37.0-rc.2"
+near-jsonrpc-primitives = "0.37.0"
+near-primitives = "0.37.0"
 serde = "1.0"
 serde_with = "3.4"
 serde_json = { version = "1.0" }

--- a/workspaces/Cargo.toml
+++ b/workspaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-workspaces"
-version = "0.23.0-rc.1"
+version = "0.23.0"
 edition.workspace = true
 rust-version.workspace = true
 license = "MIT OR Apache-2.0"
@@ -35,17 +35,16 @@ near-gas = { version = "0.3", features = ["serde", "borsh", "schemars"] }
 near-token = { version = "0.3", features = ["serde"] }
 near-sdk = { version = "5.26", optional = true }
 near-account-id = "2.0.0"
-# DRAFT: published 2.13 RC 0.37.0-rc.2; bump to 0.37.0 (drop pre-release)
-# once 2.13 ships stable.
-near-crypto = "=0.37.0-rc.2"
-near-primitives = "=0.37.0-rc.2"
-near-jsonrpc-primitives = "=0.37.0-rc.2"
-near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["sandbox"] }
-near-sandbox = "0.3.9"
-near-chain-configs = { version = "=0.37.0-rc.2", optional = true }
+# nearcore 2.13.0 stable.
+near-crypto = "0.37.0"
+near-primitives = "0.37.0"
+near-jsonrpc-primitives = "0.37.0"
+near-jsonrpc-client = { version = "0.22.0", features = ["sandbox"] }
+near-sandbox = "0.3.12"
+near-chain-configs = { version = "0.37.0", optional = true }
 
 [build-dependencies]
-near-sandbox = "0.3.9"
+near-sandbox = "0.3.12"
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/workspaces/src/rpc/tool.rs
+++ b/workspaces/src/rpc/tool.rs
@@ -81,7 +81,7 @@ pub(crate) async fn url_create_account(
             if value == b"false" {
                 return Err(ErrorKind::Other.message(format!(
                     "The new account <{}> could not be created successfully.",
-                    &account_id
+                    account_id
                 )));
             }
         }

--- a/workspaces/tests/account.rs
+++ b/workspaces/tests/account.rs
@@ -70,9 +70,10 @@ async fn test_transfer_near() -> anyhow::Result<()> {
 
 #[test(tokio::test)]
 async fn test_mldsa65_access_key_on_chain() -> anyhow::Result<()> {
-    // ML-DSA-65 (FIPS 204) access keys were stabilized in nearcore 2.13 /
-    // protocol v85. The default near-sandbox is v84 and lacks the scheme, so
-    // pin a v85 sandbox (published for linux-x86_64 + darwin) to exercise it.
+    // ML-DSA-65 (FIPS 204) access keys were stabilized in nearcore 2.13
+    // (protocol v86). Pin the 2.13.0 sandbox explicitly (published for
+    // linux-x86_64 + darwin) so this test always exercises a binary that
+    // has the scheme.
     let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let root = worker.root_account()?;
 

--- a/workspaces/tests/account.rs
+++ b/workspaces/tests/account.rs
@@ -73,7 +73,7 @@ async fn test_mldsa65_access_key_on_chain() -> anyhow::Result<()> {
     // ML-DSA-65 (FIPS 204) access keys were stabilized in nearcore 2.13 /
     // protocol v85. The default near-sandbox is v84 and lacks the scheme, so
     // pin a v85 sandbox (published for linux-x86_64 + darwin) to exercise it.
-    let worker = near_workspaces::sandbox_with_version("2.13.0-rc.1").await?;
+    let worker = near_workspaces::sandbox_with_version("2.13.0").await?;
     let root = worker.root_account()?;
 
     // Fund a fresh subaccount whose full-access key is post-quantum.


### PR DESCRIPTION
nearcore 2.13.0 is on crates.io. Swap the RC pins for the stable releases:

- `near-crypto`, `near-primitives`, `near-jsonrpc-primitives`, `near-chain-configs`: `=0.37.0-rc.2` -> `0.37.0`
- `near-jsonrpc-client`: `=0.22.0-rc.1` -> `0.22.0` (keeps `sandbox` feature)
- `near-sandbox`: `0.3.9` -> `0.3.12`, so a bare `sandbox()` defaults to the stable v86 `2.13.0` binary instead of the old v84 default
- Point the ML-DSA-65 test sandbox at the stable `2.13.0` binary
- Release `near-workspaces` `0.23.0`
